### PR TITLE
added refresh-token feature

### DIFF
--- a/backend/src/main/java/com/swipelab/controller/AuthController.java
+++ b/backend/src/main/java/com/swipelab/controller/AuthController.java
@@ -5,6 +5,7 @@ import com.swipelab.dto.request.LoginRequest;
 import com.swipelab.dto.request.RegisterRequest;
 import com.swipelab.dto.response.AuthResponse;
 import com.swipelab.exception.EmailVerificationException;
+import com.swipelab.exception.UnauthorizedException;
 import com.swipelab.service.auth.AuthenticationService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -120,5 +121,18 @@ public class AuthController {
             @Valid @RequestBody LoginRequest request) {
         return ResponseEntity.ok(authenticationService.login(request));
     }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<AuthResponse> refreshToken(
+            @RequestHeader("Authorization") String authorizationHeader) {
+
+        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+            throw new UnauthorizedException("Missing refresh token");
+        }
+
+        String refreshToken = authorizationHeader.substring(7);
+        return ResponseEntity.ok(authenticationService.refresh(refreshToken));
+    }
+
 
 }

--- a/backend/src/main/java/com/swipelab/service/auth/AuthenticationService.java
+++ b/backend/src/main/java/com/swipelab/service/auth/AuthenticationService.java
@@ -171,4 +171,9 @@ public class AuthenticationService {
                 .build();
     }
 
+    @Transactional
+    public AuthResponse refresh(String refreshToken) {
+        return jwtService.refreshTokens(refreshToken);
+    }
+
 }


### PR DESCRIPTION
**Goal (Restated Clearly)**
- Validate refresh token
- Ensure it was not revoked / reused
- Rotate refresh token (invalidate old one)
- Issue a new access token
- Return a new token pair

Where logic lives:
JwtService | Token validation + rotation
AuthenticationService | Auth workflow orchestration
Controller | HTTP only
✔ No JWT logic in controller
✔ No DB logic in controller

**JWTService**
Why this is secure:
1. Old refresh token becomes invalid immediately
2. Replay attacks are blocked
3. Only latest refresh token is valid
4. Stateless access tokens preserved

**Controller — Refresh Endpoint**
📌 Refresh token sent via Authorization header
📌 Same pattern as access token (frontend-friendly)

**Refresh Token Lifecycle (Important)**
`Login
 └─ RT₁ stored (hashed)

Refresh with RT₁
 ├─ RT₁ validated
 ├─ RT₂ issued
 └─ RT₁ hash overwritten ❌

Reuse RT₁ ❌ → Unauthorized
`