### PR TITLE
added current-user feature

### DIFF
--- a/backend/src/main/java/com/swipelab/controller/AuthController.java
+++ b/backend/src/main/java/com/swipelab/controller/AuthController.java
@@ -4,9 +4,11 @@ import com.swipelab.dto.request.EmailVerificationRequest;
 import com.swipelab.dto.request.LoginRequest;
 import com.swipelab.dto.request.RegisterRequest;
 import com.swipelab.dto.response.AuthResponse;
+import com.swipelab.dto.response.UserProfileResponse;
 import com.swipelab.exception.EmailVerificationException;
 import com.swipelab.exception.UnauthorizedException;
 import com.swipelab.service.auth.AuthenticationService;
+import com.swipelab.service.user.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -15,6 +17,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
+import java.security.Principal;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -24,6 +27,7 @@ import java.util.Map;
 public class AuthController {
 
     private final AuthenticationService authenticationService;
+    private final UserService userService;
 
     /**
      * Register a new user
@@ -146,6 +150,18 @@ public class AuthController {
         authenticationService.logout(refreshToken);
 
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<UserProfileResponse> me(Principal principal) {
+
+        if (principal == null) {
+            throw new UnauthorizedException("Unauthorized");
+        }
+
+        return ResponseEntity.ok(
+                userService.getUserProfile(principal.getName())
+        );
     }
 
 

--- a/backend/src/main/java/com/swipelab/dto/response/UserProfileResponse.java
+++ b/backend/src/main/java/com/swipelab/dto/response/UserProfileResponse.java
@@ -1,5 +1,16 @@
 package com.swipelab.dto.response;
 
+import com.swipelab.model.enums.UserRole;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
 public class UserProfileResponse {
-    
+
+    private String email;
+    private String username;
+    private UserRole role;
 }

--- a/backend/src/main/java/com/swipelab/service/user/UserService.java
+++ b/backend/src/main/java/com/swipelab/service/user/UserService.java
@@ -3,8 +3,31 @@ package com.swipelab.service.user;
 import com.swipelab.repository.UserRepository;
 import org.springframework.stereotype.Service;
 
+
+import com.swipelab.dto.response.UserProfileResponse;
+import com.swipelab.model.entity.User;
+import com.swipelab.repository.UserRepository;
+import com.swipelab.exception.UnauthorizedException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
 @Service
+@RequiredArgsConstructor
 public class UserService {
-    // TODO: Inject UserRepository
-    // TODO: Implement business logic (register, login, etc.)
+
+    private final UserRepository userRepository;
+
+    public UserProfileResponse getUserProfile(String username) {
+
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UnauthorizedException("User not found"));
+
+        return UserProfileResponse.builder()
+                .email(user.getEmail())
+                .username(user.getUsername())
+                .role(user.getRole())
+                .build();
+    }
 }


### PR DESCRIPTION
*Summary*
- Implements an endpoint to fetch the currently authenticated user’s profile
- Authentication is JWT-based and fully stateless
- The endpoint relies on Spring Security context, not manual authentication logic

*Endpoint*
- GET /api/v1/auth/me

*Request*
- Headers:
  - Authorization: Bearer <accessToken>
- Body:
  - none

*Response (200 OK)*
- email: user@example.com
- username: john_doe
- role: USER

*Error Responses*
- 401 Unauthorized
  - Missing access token
  - Invalid or expired access token

*Authentication Flow*
- JWT is extracted and validated by JwtAuthenticationFilter
- If valid, Spring Security creates an Authentication object
- The authenticated user is stored in SecurityContextHolder
- The controller accesses the authenticated user via Principal
- No authentication logic exists in the controller or service

*Implementation Details*
- AuthController
  - Exposes GET /auth/me
  - Reads the authenticated username from the security context
- UserService
  - Fetches user data by username
  - Contains no authentication or authorization logic
- UserProfileResponse
  - DTO containing email, username, and role

*Key Design Decisions*
- Authentication is handled before controller execution
- Controllers assume authentication has already succeeded
- UserService remains security-agnostic
- Username is used as the unique identifier
- Stateless JWT authentication is preserved

*Acceptance Criteria*
- Returns the correct authenticated user
- Request without JWT is rejected
- Invalid or expired JWT is rejected
- No authentication logic in service layer
- Matches the defined API contract

*Notes*
- If the controller method is invoked, authentication has already succeeded
- Token validation and user extraction never occur inside business logic
