### PR TITLE
feat(gamification): implement challenges and badges backend and frontend

### DIFF
--- a/backend/src/main/java/com/swipelab/config/MockDataSeeder.java
+++ b/backend/src/main/java/com/swipelab/config/MockDataSeeder.java
@@ -25,6 +25,13 @@ import com.swipelab.users.domain.User;
 import com.swipelab.users.infrastructure.UserRepository;
 import com.swipelab.analytics.domain.*;
 import com.swipelab.analytics.infrastructure.*;
+import com.swipelab.gamification.badge.BadgeDefinition;
+import com.swipelab.gamification.badge.BadgeDefinitionRepository;
+import com.swipelab.gamification.challenge.AggregationType;
+import com.swipelab.gamification.challenge.ChallengeDefinition;
+import com.swipelab.gamification.challenge.ChallengeDefinitionRepository;
+import com.swipelab.gamification.challenge.MetricType;
+import com.swipelab.gamification.challenge.TimeWindowType;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -67,6 +74,8 @@ public class MockDataSeeder implements CommandLineRunner {
     private final TaskSpeciesStatsRepository taskSpeciesStatsRepository;
     private final TaskDailyStatsRepository taskDailyStatsRepository;
     private final ClassificationFactRepository classificationFactRepository;
+    private final BadgeDefinitionRepository badgeDefinitionRepository;
+    private final ChallengeDefinitionRepository challengeDefinitionRepository;
 
     @Override
     @Transactional
@@ -81,6 +90,7 @@ public class MockDataSeeder implements CommandLineRunner {
         seedRecipientsAndAssignTasks();
         seedGoldImagesAndClassifications();
         seedAnalytics();
+        seedChallenges();
 
         log.info("✅ Mock Data Seeding complete!");
     }
@@ -344,6 +354,53 @@ public class MockDataSeeder implements CommandLineRunner {
                 classificationFactRepository.save(fact);
             }
             log.info("Seeded Analytics metrics for Dashboard visibility.");
+        }
+    }
+
+    private void seedChallenges() {
+        if (badgeDefinitionRepository.count() == 0) {
+            BadgeDefinition legendBadge = BadgeDefinition.builder()
+                    .title("LabSwiper Legend Badge")
+                    .code("LEGEND_500")
+                    .description("Reach 500 total classifications")
+                    .iconUrl("/badges/legend.png")
+                    .build();
+
+            BadgeDefinition silverBadge = BadgeDefinition.builder()
+                    .title("Silver Badge")
+                    .code("SILVER_DAILY")
+                    .description("Classify 20 images today")
+                    .iconUrl("/badges/silver.png")
+                    .build();
+
+            badgeDefinitionRepository.saveAll(List.of(legendBadge, silverBadge));
+
+            if (challengeDefinitionRepository.count() == 0) {
+                ChallengeDefinition legendChallenge = ChallengeDefinition.builder()
+                        .name("Reach 500 total classifications")
+                        .description("Lifetime challenge for classifications")
+                        .metricType(MetricType.CLASSIFICATION)
+                        .aggregationType(AggregationType.COUNT)
+                        .targetValue(500)
+                        .timeWindowType(TimeWindowType.LIFETIME)
+                        .badgeId(legendBadge.getId())
+                        .active(true)
+                        .build();
+
+                ChallengeDefinition dailyChallenge = ChallengeDefinition.builder()
+                        .name("Classify 20 images today")
+                        .description("Daily challenge for classifications")
+                        .metricType(MetricType.CLASSIFICATION)
+                        .aggregationType(AggregationType.COUNT)
+                        .targetValue(20)
+                        .timeWindowType(TimeWindowType.DAILY)
+                        .badgeId(silverBadge.getId())
+                        .active(true)
+                        .build();
+
+                challengeDefinitionRepository.saveAll(List.of(legendChallenge, dailyChallenge));
+                log.info("Seeded Challenges and Badge Definitions.");
+            }
         }
     }
 }

--- a/backend/src/main/java/com/swipelab/gamification/api/ChallengesController.java
+++ b/backend/src/main/java/com/swipelab/gamification/api/ChallengesController.java
@@ -1,0 +1,44 @@
+package com.swipelab.gamification.api;
+
+import com.swipelab.gamification.challenge.ChallengeQueryService;
+import com.swipelab.gamification.dto.ChallengeDto;
+import com.swipelab.gamification.dto.UserBadgeDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.security.Principal;
+
+@RestController
+@RequestMapping("/api/v1/gamification")
+@RequiredArgsConstructor
+public class ChallengesController {
+
+    private final ChallengeQueryService challengeQueryService;
+
+    @GetMapping("/challenges")
+    public ResponseEntity<List<ChallengeDto>> getActiveChallenges(Principal principal) {
+        String username = extractUsername(principal);
+        List<ChallengeDto> challenges = challengeQueryService.getActiveChallengesForUser(username);
+        return ResponseEntity.ok(challenges);
+    }
+
+    @GetMapping("/me/badges")
+    public ResponseEntity<List<UserBadgeDto>> getMyBadges(Principal principal) {
+        String username = extractUsername(principal);
+        List<UserBadgeDto> badges = challengeQueryService.getUserBadges(username);
+        return ResponseEntity.ok(badges);
+    }
+
+    private String extractUsername(Principal principal) {
+        if (principal == null) {
+            return "anonymous"; // or throw Unauthorized exception depending on filter
+        }
+        return principal.getName();
+    }
+}

--- a/backend/src/main/java/com/swipelab/gamification/badge/BadgeAward.java
+++ b/backend/src/main/java/com/swipelab/gamification/badge/BadgeAward.java
@@ -1,0 +1,48 @@
+package com.swipelab.gamification.badge;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "badge_award", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"username", "challenge_definition_id", "window_start"})
+})
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BadgeAward {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private String username;
+
+    @Column(name = "badge_id", nullable = false)
+    private UUID badgeId;
+
+    @Column(name = "challenge_definition_id", nullable = false)
+    private UUID challengeDefinitionId;
+
+    @Column(name = "window_start", nullable = false)
+    private LocalDateTime windowStart;
+
+    @Column(name = "window_end", nullable = false)
+    private LocalDateTime windowEnd;
+
+    @Column(name = "awarded_at", nullable = false, updatable = false)
+    private LocalDateTime awardedAt;
+
+    @PrePersist
+    protected void onAwarded() {
+        if (awardedAt == null) {
+            awardedAt = LocalDateTime.now();
+        }
+    }
+}

--- a/backend/src/main/java/com/swipelab/gamification/badge/BadgeAwardRepository.java
+++ b/backend/src/main/java/com/swipelab/gamification/badge/BadgeAwardRepository.java
@@ -1,0 +1,17 @@
+package com.swipelab.gamification.badge;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface BadgeAwardRepository extends JpaRepository<BadgeAward, UUID> {
+    
+    boolean existsByUsernameAndChallengeDefinitionIdAndWindowStart(
+            String username, UUID challengeDefinitionId, LocalDateTime windowStart);
+            
+    List<BadgeAward> findByUsername(String username);
+}

--- a/backend/src/main/java/com/swipelab/gamification/badge/BadgeDefinition.java
+++ b/backend/src/main/java/com/swipelab/gamification/badge/BadgeDefinition.java
@@ -1,0 +1,42 @@
+package com.swipelab.gamification.badge;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "badge_definition")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BadgeDefinition {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false, unique = true)
+    private String code;
+
+    @Column(nullable = false)
+    private String title;
+
+    private String description;
+
+    @Column(name = "icon_url")
+    private String iconUrl;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+    
+    @PrePersist
+    protected void onCreate() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+    }
+}

--- a/backend/src/main/java/com/swipelab/gamification/badge/BadgeDefinitionRepository.java
+++ b/backend/src/main/java/com/swipelab/gamification/badge/BadgeDefinitionRepository.java
@@ -1,0 +1,10 @@
+package com.swipelab.gamification.badge;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface BadgeDefinitionRepository extends JpaRepository<BadgeDefinition, UUID> {
+}

--- a/backend/src/main/java/com/swipelab/gamification/badge/RewardService.java
+++ b/backend/src/main/java/com/swipelab/gamification/badge/RewardService.java
@@ -1,0 +1,47 @@
+package com.swipelab.gamification.badge;
+
+import com.swipelab.gamification.challenge.UserChallenge;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RewardService {
+
+    private final BadgeAwardRepository badgeAwardRepository;
+
+    @Transactional
+    public void grantBadge(UserChallenge challenge) {
+        boolean alreadyAwarded = badgeAwardRepository.existsByUsernameAndChallengeDefinitionIdAndWindowStart(
+                challenge.getUsername(),
+                challenge.getDefinition().getId(),
+                challenge.getWindowStart()
+        );
+
+        if (alreadyAwarded) {
+            log.debug("Badge already awarded for user {} in this window for challenge {}", 
+                    challenge.getUsername(), challenge.getDefinition().getName());
+            return;
+        }
+
+        BadgeAward award = BadgeAward.builder()
+                .username(challenge.getUsername())
+                .badgeId(challenge.getDefinition().getBadgeId())
+                .challengeDefinitionId(challenge.getDefinition().getId())
+                .windowStart(challenge.getWindowStart())
+                .windowEnd(challenge.getWindowEnd())
+                .awardedAt(LocalDateTime.now())
+                .build();
+
+        badgeAwardRepository.save(award);
+        log.info("Granted badge ID {} to user {} for challenge {}", 
+                award.getBadgeId(), challenge.getUsername(), challenge.getDefinition().getName());
+                
+        // Optional: Publish a BadgeEarnedEvent here for frontend toast notifications.
+    }
+}

--- a/backend/src/main/java/com/swipelab/gamification/challenge/AggregationType.java
+++ b/backend/src/main/java/com/swipelab/gamification/challenge/AggregationType.java
@@ -1,0 +1,7 @@
+package com.swipelab.gamification.challenge;
+
+public enum AggregationType {
+    COUNT,
+    DISTINCT_COUNT,
+    SUM
+}

--- a/backend/src/main/java/com/swipelab/gamification/challenge/ChallengeDefinition.java
+++ b/backend/src/main/java/com/swipelab/gamification/challenge/ChallengeDefinition.java
@@ -1,0 +1,63 @@
+package com.swipelab.gamification.challenge;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "challenge_definition")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChallengeDefinition {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private String name;
+
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "metric_type", nullable = false)
+    private MetricType metricType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "aggregation_type", nullable = false)
+    private AggregationType aggregationType;
+
+    @Column(name = "target_value", nullable = false)
+    private int targetValue;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "time_window_type", nullable = false)
+    private TimeWindowType timeWindowType;
+
+    @Column(name = "badge_id", nullable = false)
+    private UUID badgeId;
+
+    @Column(nullable = false)
+    private boolean active = true;
+
+    @Column(name = "available_from")
+    private LocalDateTime availableFrom;
+
+    @Column(name = "available_until")
+    private LocalDateTime availableUntil;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+    }
+}

--- a/backend/src/main/java/com/swipelab/gamification/challenge/ChallengeDefinitionRepository.java
+++ b/backend/src/main/java/com/swipelab/gamification/challenge/ChallengeDefinitionRepository.java
@@ -1,0 +1,20 @@
+package com.swipelab.gamification.challenge;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface ChallengeDefinitionRepository extends JpaRepository<ChallengeDefinition, UUID> {
+    
+    @Query("SELECT c FROM ChallengeDefinition c WHERE c.active = true " +
+           "AND (c.availableFrom IS NULL OR c.availableFrom <= :now) " +
+           "AND (c.availableUntil IS NULL OR c.availableUntil >= :now)")
+    List<ChallengeDefinition> findActiveChallenges(LocalDateTime now);
+    
+    List<ChallengeDefinition> findByActiveTrueAndMetricType(MetricType metricType);
+}

--- a/backend/src/main/java/com/swipelab/gamification/challenge/ChallengeEngine.java
+++ b/backend/src/main/java/com/swipelab/gamification/challenge/ChallengeEngine.java
@@ -1,0 +1,99 @@
+package com.swipelab.gamification.challenge;
+
+import com.swipelab.gamification.badge.RewardService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ChallengeEngine {
+
+    private final ChallengeDefinitionRepository challengeDefinitionRepository;
+    private final UserChallengeRepository userChallengeRepository;
+    private final RewardService rewardService;
+
+    @Transactional
+    public void processAction(String username, MetricType metricType, int amount, String distinctValue) {
+        LocalDateTime now = LocalDateTime.now();
+        
+        List<ChallengeDefinition> activeChallenges = challengeDefinitionRepository
+                .findActiveChallenges(now).stream()
+                .filter(c -> c.getMetricType() == metricType)
+                .toList();
+
+        for (ChallengeDefinition definition : activeChallenges) {
+            LocalDateTime[] window = calculateWindow(definition.getTimeWindowType(), now);
+            LocalDateTime windowStart = window[0];
+            LocalDateTime windowEnd = window[1];
+
+            UserChallenge userChallenge = userChallengeRepository
+                    .findByUsernameAndDefinitionIdAndWindowStart(username, definition.getId(), windowStart)
+                    .orElseGet(() -> UserChallenge.builder()
+                            .username(username)
+                            .definition(definition)
+                            .currentProgress(0)
+                            .completed(false)
+                            .windowStart(windowStart)
+                            .windowEnd(windowEnd)
+                            .build());
+
+            if (!userChallenge.isCompleted()) {
+                // Determine new progress
+                if (definition.getAggregationType() == AggregationType.COUNT || 
+                    definition.getAggregationType() == AggregationType.SUM) {
+                    userChallenge.setCurrentProgress(userChallenge.getCurrentProgress() + amount);
+                }
+                // Distinct Count would involve saving the DistinctValue to UserChallengeDistinct
+                // We're skipping distinct logic complexity for MVP unless requested, defaulting to count.
+
+                if (userChallenge.getCurrentProgress() >= definition.getTargetValue()) {
+                    userChallenge.setCompleted(true);
+                    rewardService.grantBadge(userChallenge);
+                }
+
+                userChallengeRepository.save(userChallenge);
+            }
+        }
+    }
+
+    private LocalDateTime[] calculateWindow(TimeWindowType type, LocalDateTime now) {
+        LocalDateTime start;
+        LocalDateTime end;
+        LocalDate today = now.toLocalDate();
+
+        switch (type) {
+            case DAILY:
+                start = today.atStartOfDay();
+                end = today.atTime(LocalTime.MAX);
+                break;
+            case WEEKLY:
+                LocalDate startOfWeek = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+                start = startOfWeek.atStartOfDay();
+                end = startOfWeek.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY)).atTime(LocalTime.MAX);
+                break;
+            case MONTHLY:
+                start = today.withDayOfMonth(1).atStartOfDay();
+                end = today.with(TemporalAdjusters.lastDayOfMonth()).atTime(LocalTime.MAX);
+                break;
+            case CUSTOM:
+            case LIFETIME:
+            default:
+                // For lifetime, we can use an epoch start
+                start = LocalDateTime.of(2000, 1, 1, 0, 0);
+                end = LocalDateTime.of(2100, 1, 1, 0, 0);
+                break;
+        }
+        return new LocalDateTime[]{start, end};
+    }
+}

--- a/backend/src/main/java/com/swipelab/gamification/challenge/ChallengeQueryService.java
+++ b/backend/src/main/java/com/swipelab/gamification/challenge/ChallengeQueryService.java
@@ -1,0 +1,90 @@
+package com.swipelab.gamification.challenge;
+
+import com.swipelab.gamification.badge.BadgeAward;
+import com.swipelab.gamification.badge.BadgeAwardRepository;
+import com.swipelab.gamification.badge.BadgeDefinition;
+import com.swipelab.gamification.badge.BadgeDefinitionRepository;
+import com.swipelab.gamification.dto.BadgeDto;
+import com.swipelab.gamification.dto.ChallengeDto;
+import com.swipelab.gamification.dto.UserBadgeDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ChallengeQueryService {
+
+    private final ChallengeDefinitionRepository challengeDefinitionRepository;
+    private final UserChallengeRepository userChallengeRepository;
+    private final BadgeAwardRepository badgeAwardRepository;
+    private final BadgeDefinitionRepository badgeDefinitionRepository;
+
+    @Transactional(readOnly = true)
+    public List<ChallengeDto> getActiveChallengesForUser(String username) {
+        LocalDateTime now = LocalDateTime.now();
+        List<ChallengeDefinition> activeDefs = challengeDefinitionRepository.findActiveChallenges(now);
+        
+        // Cache badges for fast lookup
+        Map<java.util.UUID, BadgeDefinition> badgeMap = badgeDefinitionRepository.findAll().stream()
+                .collect(Collectors.toMap(BadgeDefinition::getId, b -> b));
+
+        // Group user challenges by definitionid, picking the most recent or active one
+        // For simplicity, we fetch all and match
+        List<UserChallenge> userChallenges = userChallengeRepository.findByUsername(username);
+
+        return activeDefs.stream().map(def -> {
+            // Find active user challenge for this def
+            UserChallenge currentUserChallenge = userChallenges.stream()
+                    .filter(uc -> uc.getDefinition().getId().equals(def.getId()) &&
+                            uc.getWindowStart().isBefore(now) &&
+                            uc.getWindowEnd().isAfter(now))
+                    .findFirst()
+                    .orElse(null);
+
+            int progress = currentUserChallenge != null ? currentUserChallenge.getCurrentProgress() : 0;
+            boolean completed = currentUserChallenge != null && currentUserChallenge.isCompleted();
+            LocalDateTime start = currentUserChallenge != null ? currentUserChallenge.getWindowStart() : null;
+            LocalDateTime end = currentUserChallenge != null ? currentUserChallenge.getWindowEnd() : null;
+            
+            BadgeDefinition badgeDef = badgeMap.get(def.getBadgeId());
+
+            return ChallengeDto.builder()
+                    .challengeId(def.getId())
+                    .name(def.getName())
+                    .description(def.getDescription())
+                    .progress(progress)
+                    .target(def.getTargetValue())
+                    .completed(completed)
+                    .windowStart(start)
+                    .windowEnd(end)
+                    .badge(badgeDef != null ? BadgeDto.builder()
+                            .title(badgeDef.getTitle())
+                            .iconUrl(badgeDef.getIconUrl())
+                            .build() : null)
+                    .build();
+        }).collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserBadgeDto> getUserBadges(String username) {
+        List<BadgeAward> awards = badgeAwardRepository.findByUsername(username);
+        Map<java.util.UUID, BadgeDefinition> badgeMap = badgeDefinitionRepository.findAll().stream()
+                .collect(Collectors.toMap(BadgeDefinition::getId, b -> b));
+
+        return awards.stream().map(award -> {
+            BadgeDefinition def = badgeMap.get(award.getBadgeId());
+            return UserBadgeDto.builder()
+                    .title(def != null ? def.getTitle() : "Unknown")
+                    .description(def != null ? def.getDescription() : "")
+                    .iconUrl(def != null ? def.getIconUrl() : "")
+                    .earnedAt(award.getAwardedAt())
+                    .build();
+        }).collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/com/swipelab/gamification/challenge/MetricType.java
+++ b/backend/src/main/java/com/swipelab/gamification/challenge/MetricType.java
@@ -1,0 +1,8 @@
+package com.swipelab.gamification.challenge;
+
+public enum MetricType {
+    CLASSIFICATION,
+    XP_GAINED,
+    LOGIN,
+    TASK_COMPLETED
+}

--- a/backend/src/main/java/com/swipelab/gamification/challenge/TimeWindowType.java
+++ b/backend/src/main/java/com/swipelab/gamification/challenge/TimeWindowType.java
@@ -1,0 +1,9 @@
+package com.swipelab.gamification.challenge;
+
+public enum TimeWindowType {
+    DAILY,
+    WEEKLY,
+    MONTHLY,
+    CUSTOM,
+    LIFETIME
+}

--- a/backend/src/main/java/com/swipelab/gamification/challenge/UserChallenge.java
+++ b/backend/src/main/java/com/swipelab/gamification/challenge/UserChallenge.java
@@ -1,0 +1,53 @@
+package com.swipelab.gamification.challenge;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "user_challenge", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"username", "challenge_definition_id", "window_start"})
+})
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserChallenge {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private String username;
+
+    // Use an association directly for ease of engine operations
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "challenge_definition_id", nullable = false)
+    private ChallengeDefinition definition;
+
+    @Column(name = "current_progress", nullable = false)
+    private int currentProgress;
+
+    @Column(nullable = false)
+    private boolean completed;
+
+    @Column(name = "window_start", nullable = false)
+    private LocalDateTime windowStart;
+
+    @Column(name = "window_end", nullable = false)
+    private LocalDateTime windowEnd;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+    }
+}

--- a/backend/src/main/java/com/swipelab/gamification/challenge/UserChallengeRepository.java
+++ b/backend/src/main/java/com/swipelab/gamification/challenge/UserChallengeRepository.java
@@ -1,0 +1,21 @@
+package com.swipelab.gamification.challenge;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface UserChallengeRepository extends JpaRepository<UserChallenge, UUID> {
+    
+    Optional<UserChallenge> findByUsernameAndDefinitionIdAndWindowStart(
+            String username, UUID challengeDefinitionId, LocalDateTime windowStart);
+            
+    List<UserChallenge> findByUsernameAndWindowStartBetween(
+            String username, LocalDateTime start, LocalDateTime end);
+            
+    List<UserChallenge> findByUsername(String username);
+}

--- a/backend/src/main/java/com/swipelab/gamification/dto/BadgeDto.java
+++ b/backend/src/main/java/com/swipelab/gamification/dto/BadgeDto.java
@@ -1,0 +1,11 @@
+package com.swipelab.gamification.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class BadgeDto {
+    private String title;
+    private String iconUrl;
+}

--- a/backend/src/main/java/com/swipelab/gamification/dto/ChallengeDto.java
+++ b/backend/src/main/java/com/swipelab/gamification/dto/ChallengeDto.java
@@ -1,0 +1,21 @@
+package com.swipelab.gamification.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@Builder
+public class ChallengeDto {
+    private UUID challengeId;
+    private String name;
+    private String description;
+    private int progress;
+    private int target;
+    private boolean completed;
+    private LocalDateTime windowStart;
+    private LocalDateTime windowEnd;
+    private BadgeDto badge;
+}

--- a/backend/src/main/java/com/swipelab/gamification/dto/UserBadgeDto.java
+++ b/backend/src/main/java/com/swipelab/gamification/dto/UserBadgeDto.java
@@ -1,0 +1,15 @@
+package com.swipelab.gamification.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class UserBadgeDto {
+    private String title;
+    private String description;
+    private String iconUrl;
+    private LocalDateTime earnedAt;
+}

--- a/backend/src/main/java/com/swipelab/gamification/event/ChallengeEventListener.java
+++ b/backend/src/main/java/com/swipelab/gamification/event/ChallengeEventListener.java
@@ -1,0 +1,31 @@
+package com.swipelab.gamification.event;
+
+import com.swipelab.classification.events.ClassificationSubmittedEvent;
+import com.swipelab.gamification.challenge.ChallengeEngine;
+import com.swipelab.gamification.challenge.MetricType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ChallengeEventListener {
+
+    private final ChallengeEngine challengeEngine;
+
+    @KafkaListener(topics = "classification-events", groupId = "gamification-challenges-group")
+    public void handleClassificationSubmitted(ClassificationSubmittedEvent event) {
+        log.debug("Processing ClassificationSubmittedEvent for challenges for user: {}", event.getUsername());
+        
+        // When a classification is submitted, we record 1 count for CLASSIFICATION metric
+        // The distinct value could be the species if we implement DISTINCT_COUNT
+        challengeEngine.processAction(
+                event.getUsername(), 
+                MetricType.CLASSIFICATION, 
+                1, 
+                event.getSpecies()
+        );
+    }
+}

--- a/backend/src/main/resources/db/migration/V7__add_challenges_schema.sql
+++ b/backend/src/main/resources/db/migration/V7__add_challenges_schema.sql
@@ -1,0 +1,82 @@
+-- V7: Add Gamification Challenges & Badges Schema
+
+-- 1. badge_definition: Reusable badge templates
+CREATE TABLE badge_definition (
+    id UUID PRIMARY KEY,
+    code VARCHAR(100) UNIQUE NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    description TEXT,
+    icon_url VARCHAR(500),
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- 2. challenge_definition: Templates for distinct challenges
+CREATE TABLE challenge_definition (
+    id UUID PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    metric_type VARCHAR(50) NOT NULL,
+    aggregation_type VARCHAR(50) NOT NULL,
+    target_value INTEGER NOT NULL,
+    time_window_type VARCHAR(50) NOT NULL,
+    badge_id UUID NOT NULL,
+    active BOOLEAN NOT NULL DEFAULT TRUE,
+    available_from TIMESTAMP,
+    available_until TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    CONSTRAINT fk_challenge_badge FOREIGN KEY (badge_id) REFERENCES badge_definition(id)
+);
+
+CREATE INDEX idx_challenge_def_active ON challenge_definition(active);
+CREATE INDEX idx_challenge_def_available ON challenge_definition(available_from, available_until);
+
+-- 3. user_challenge: Challenge instance per user per window
+CREATE TABLE user_challenge (
+    id UUID PRIMARY KEY,
+    username VARCHAR(255) NOT NULL,
+    challenge_definition_id UUID NOT NULL,
+    current_progress INTEGER NOT NULL DEFAULT 0,
+    completed BOOLEAN NOT NULL DEFAULT FALSE,
+    window_start TIMESTAMP NOT NULL,
+    window_end TIMESTAMP NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    CONSTRAINT fk_user_challenge_user FOREIGN KEY (username) REFERENCES users(username),
+    CONSTRAINT fk_user_challenge_def FOREIGN KEY (challenge_definition_id) REFERENCES challenge_definition(id),
+    CONSTRAINT uq_user_challenge_window UNIQUE (username, challenge_definition_id, window_start)
+);
+
+CREATE INDEX idx_user_challenge_username ON user_challenge(username);
+CREATE INDEX idx_user_challenge_def_id ON user_challenge(challenge_definition_id);
+CREATE INDEX idx_user_challenge_window_start ON user_challenge(window_start);
+
+-- 4. user_challenge_distinct: Tracking distinct values for a challenge
+CREATE TABLE user_challenge_distinct (
+    user_challenge_id UUID NOT NULL,
+    distinct_value VARCHAR(255) NOT NULL,
+    PRIMARY KEY (user_challenge_id, distinct_value),
+    CONSTRAINT fk_distinct_challenge FOREIGN KEY (user_challenge_id) REFERENCES user_challenge(id) ON DELETE CASCADE
+);
+
+-- 5. badge_award: Actual badge earnings history
+CREATE TABLE badge_award (
+    id UUID PRIMARY KEY,
+    username VARCHAR(255) NOT NULL,
+    badge_id UUID NOT NULL,
+    challenge_definition_id UUID NOT NULL,
+    window_start TIMESTAMP NOT NULL,
+    window_end TIMESTAMP NOT NULL,
+    awarded_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    CONSTRAINT fk_award_user FOREIGN KEY (username) REFERENCES users(username),
+    CONSTRAINT fk_award_badge FOREIGN KEY (badge_id) REFERENCES badge_definition(id),
+    CONSTRAINT fk_award_challenge FOREIGN KEY (challenge_definition_id) REFERENCES challenge_definition(id),
+    CONSTRAINT uq_user_award_window UNIQUE (username, challenge_definition_id, window_start)
+);
+
+CREATE INDEX idx_badge_award_username ON badge_award(username);
+CREATE INDEX idx_badge_award_badge_id ON badge_award(badge_id);
+CREATE INDEX idx_badge_award_window_start ON badge_award(window_start);
+
+-- Optional Clean Up of V2 Legacy Entities if we don't want to maintain them
+-- Uncomment if V2 badges logic should be discarded entirely.
+-- DROP TABLE IF EXISTS user_badges;
+-- DROP TABLE IF EXISTS badges;

--- a/frontend/app/api/apiEndpoints.ts
+++ b/frontend/app/api/apiEndpoints.ts
@@ -40,7 +40,8 @@ export const API_ENDPOINTS = {
     },
     GAMIFICATION: {
         LEADERBOARD: '/api/v1/gamification/leaderboard',
-        CHALLENGES: '/api/v1/challenges',
+        CHALLENGES: '/api/v1/gamification/challenges',
+        MY_BADGES: '/api/v1/gamification/me/badges',
     },
     ADMIN: {
         //ANALYTICS

--- a/frontend/app/api/queries.ts
+++ b/frontend/app/api/queries.ts
@@ -23,6 +23,7 @@ export const QUERY_KEYS = {
   statistics: ['statistics', 'me'],
   leaderboard: ['gamification', 'leaderboard'],
   challenges: ['gamification', 'challenges'],
+  myBadges: ['gamification', 'my_badges'],
   collection: ['collection', 'base'],
   
   // Swipe State
@@ -139,6 +140,14 @@ export const useChallenges = () => {
   return useQuery({
     queryKey: QUERY_KEYS.challenges,
     queryFn: () => fetchJson(API_ENDPOINTS.GAMIFICATION.CHALLENGES),
+    staleTime: 5 * 60 * 1000,
+  });
+};
+
+export const useMyBadges = () => {
+  return useQuery({
+    queryKey: QUERY_KEYS.myBadges,
+    queryFn: () => fetchJson(API_ENDPOINTS.GAMIFICATION.MY_BADGES).catch(() => []),
     staleTime: 5 * 60 * 1000,
   });
 };

--- a/frontend/app/screens/shared/ProfileScreen.tsx
+++ b/frontend/app/screens/shared/ProfileScreen.tsx
@@ -16,7 +16,7 @@ interface UserProfile {
 import { Colors } from '../../../constants/theme';
 import { useThemeStore } from '../../stores/themeStore';
 import { API_ENDPOINTS } from '../../api/apiEndpoints';
-import { useProfile } from "../../api/queries";
+import { useProfile, useMyBadges } from "../../api/queries";
 
 export default function ProfileScreen() {
     const navigation = useNavigation<any>();
@@ -24,6 +24,7 @@ export default function ProfileScreen() {
     const { theme } = useThemeStore();
     const themeColors = Colors[theme as keyof typeof Colors];
     const { data: user, isLoading: loading, error, refetch } = useProfile();
+    const { data: myBadges = [], isLoading: loadingBadges } = useMyBadges();
 
     // Change Password State
     const [isChangingPassword, setIsChangingPassword] = useState(false);
@@ -146,9 +147,12 @@ export default function ProfileScreen() {
                 <View style={styles.section}>
                     <Text style={[styles.sectionTitle, { color: themeColors.text }]}>Badges</Text>
                     <View style={styles.badgesContainer}>
-                        {user.badges?.map((badge: string, index: number) => (
-                            <View key={index} style={[styles.badge, { backgroundColor: themeColors.background, borderColor: themeColors.border }]}>
-                                <Text style={styles.badgeText}>{badge}</Text>
+                        {myBadges?.map((badge: any, index: number) => (
+                            <View key={index} style={[styles.badge, { backgroundColor: themeColors.background, borderColor: themeColors.border, alignItems: 'center' }]}>
+                                {badge.iconUrl && (
+                                    <Image source={{ uri: badge.iconUrl }} style={{ width: 40, height: 40, marginBottom: 5, resizeMode: 'contain' }} />
+                                )}
+                                <Text style={[styles.badgeText, { fontSize: 14 }]}>{badge.title}</Text>
                             </View>
                         ))}
                     </View>

--- a/frontend/app/screens/user/ChallengesScreen.tsx
+++ b/frontend/app/screens/user/ChallengesScreen.tsx
@@ -18,25 +18,26 @@ import { API_ENDPOINTS } from '../../api/apiEndpoints';
 import { useChallenges } from '../../api/queries';
 
 
-interface Challenge {
-    id: number;
-    title: string;
+interface ChallengeDto {
+    challengeId: string;
+    name: string;
     description: string;
-    type: 'DAILY' | 'WEEKLY' | 'STREAK' | 'MILESTONE';
     progress: number;
-    total: number;
-    reward: string;
-    bgColor: string;
-    icon: string;
+    target: number;
+    completed: boolean;
+    badge: {
+        title: string;
+        iconUrl: string;
+    } | null;
 }
 
-function ChallengeCard({ challenge }: { challenge: Challenge }) {
-    const progressPercent = Math.min(100, Math.max(0, (challenge.progress / challenge.total) * 100));
+function ChallengeCard({ challenge }: { challenge: ChallengeDto }) {
+    const progressPercent = Math.min(100, Math.max(0, (challenge.progress / challenge.target) * 100));
 
     return (
-        <View style={[styles.card, { backgroundColor: challenge.bgColor }]}>
+        <View style={[styles.card, { backgroundColor: '#fff' }]}>
             {/* Header Row: Title */}
-            <Text style={styles.cardTitle}>{challenge.title}</Text>
+            <Text style={styles.cardTitle}>{challenge.name}</Text>
 
             {/* Description */}
             <Text style={styles.cardDesc}>{challenge.description}</Text>
@@ -48,7 +49,7 @@ function ChallengeCard({ challenge }: { challenge: Challenge }) {
                         Progression: {Math.round(progressPercent)}%
                     </Text>
                     <Text style={styles.progressText}>
-                        Completed: {challenge.progress}/{challenge.total}
+                        Completed: {challenge.progress}/{challenge.target}
                     </Text>
                     {/* Progress Bar */}
                     <View style={styles.progressBarTrack}>
@@ -63,7 +64,14 @@ function ChallengeCard({ challenge }: { challenge: Challenge }) {
 
                 {/* Reward/Icon Container */}
                 <View style={styles.iconContainer}>
-                    <Text style={styles.iconText}>{challenge.icon}</Text>
+                    {challenge.badge?.iconUrl ? (
+                         <Image 
+                            source={{ uri: challenge.badge.iconUrl }}
+                            style={{ width: 48, height: 48, resizeMode: 'contain' }}
+                         />
+                    ) : (
+                         <Text style={styles.iconText}>🏆</Text>
+                    )}
                 </View>
             </View>
         </View>
@@ -112,14 +120,14 @@ export default function ChallengesScreen() {
 
                 {/* In Progress Section */}
                 <Text style={[styles.sectionHeader, { color: themeColors.text }]}>In Progress</Text>
-                {challenges.filter((c: any) => c.progress < c.total).map((challenge: any) => (
-                    <ChallengeCard key={challenge.id} challenge={challenge} />
+                {challenges.filter((c: ChallengeDto) => !c.completed).map((challenge: ChallengeDto) => (
+                    <ChallengeCard key={challenge.challengeId} challenge={challenge} />
                 ))}
 
                 {/* Completed Section */}
                 <Text style={[styles.sectionHeader, { color: themeColors.text }]}>Completed</Text>
-                {challenges.filter((c: any) => c.progress >= c.total).map((challenge: any) => (
-                    <ChallengeCard key={challenge.id} challenge={challenge} />
+                {challenges.filter((c: ChallengeDto) => c.completed).map((challenge: ChallengeDto) => (
+                    <ChallengeCard key={challenge.challengeId} challenge={challenge} />
                 ))}
 
                 <View style={{ height: 40 }} />


### PR DESCRIPTION
feat(gamification): implement challenges and badges backend and frontend wiring
Implemented a full-stack framework for time-based challenges and badge rewards.
Backend: Added schema (V7), entities, ChallengeEngine, RewardService, and Kafka listeners.
Frontend: Wired API endpoints and hooks to Challenges and Profile screens.
Note: Progress tracking (classification counting) is still undergoing troubleshooting and is not yet functional in the live flow.