### PR TITLE
Fix pause and archive buttons not updating task status (#176)

### DIFF
--- a/frontend/app/api/apiEndpoints.ts
+++ b/frontend/app/api/apiEndpoints.ts
@@ -21,6 +21,9 @@ export const API_ENDPOINTS = {
         PLAY_TASK: (taskId: string | number) => `/api/v1/classifications/tasks/${taskId}/play`,
         CREATE_TASK: '/api/v1/tasks/create',
         UPDATE_TASK: (taskId: string | number) => `/api/v1/tasks/${taskId}`,
+        PAUSE_TASK: (taskId: string | number) => `/api/v1/tasks/${taskId}/pause`,
+        ARCHIVE_TASK: (taskId: string | number) => `/api/v1/tasks/${taskId}/archive`,
+        ACTIVATE_TASK: (taskId: string | number) => `/api/v1/tasks/${taskId}/activate`,
     },
     CLASSIFICATIONS: {
         NEXT_BATCH: (taskId: string | number, count: number = 5) =>

--- a/frontend/app/api/queries.ts
+++ b/frontend/app/api/queries.ts
@@ -215,6 +215,25 @@ export const useSwipeBatch = (taskId: string | number) => {
   });
 };
 
+export const useUpdateTaskStatus = () => {
+  const queryClient = useQueryClient();
+  
+  return useMutation({
+    mutationFn: async ({ taskId, action }: { taskId: string | number, action: 'pause' | 'archive' | 'activate' }) => {
+      const endpoint = action === 'pause' ? API_ENDPOINTS.TASKS.PAUSE_TASK(taskId) :
+                       action === 'archive' ? API_ENDPOINTS.TASKS.ARCHIVE_TASK(taskId) :
+                       API_ENDPOINTS.TASKS.ACTIVATE_TASK(taskId);
+      const res = await apiFetch(endpoint, { method: 'POST' });
+      if (!res.ok) throw new Error(`Failed to ${action} task`);
+      return res.json();
+    },
+    onSuccess: (updatedTask, { taskId }) => {
+      queryClient.setQueryData(QUERY_KEYS.taskDetails(taskId), updatedTask);
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.dashboardTasks });
+    }
+  });
+};
+
 import { queryClient } from '../queryClient';
 
 export const preloadAfterLogin = async (role: string) => {

--- a/frontend/app/screens/admin/TaskDetailsScreen.tsx
+++ b/frontend/app/screens/admin/TaskDetailsScreen.tsx
@@ -7,7 +7,7 @@ import { Colors } from '../../../constants/theme';
 import { apiFetch } from "../../api/apiFetch";
 import { AdminStackParamList } from "../../navigation/adminStack.types";
 import { useThemeStore } from '../../stores/themeStore';
-import { useTaskDetails, useExperiments } from "../../api/queries";
+import { useTaskDetails, useExperiments, useUpdateTaskStatus } from "../../api/queries";
 
 
 type Props = NativeStackScreenProps<AdminStackParamList, "TaskDetails">;
@@ -36,6 +36,7 @@ export default function TaskDetailsScreen({ route, navigation }: Props) {
 
   const { data: task, isLoading: loading, error } = useTaskDetails(taskId);
   const { data: experimentsList } = useExperiments();
+  const { mutate: updateStatus } = useUpdateTaskStatus();
 
   if (loading) return <Text style={styles.loading}>Loading...</Text>;
   if (error) return <Text style={styles.error}>Error: {(error as Error).message || "Failed to fetch task"}</Text>;
@@ -64,7 +65,7 @@ export default function TaskDetailsScreen({ route, navigation }: Props) {
             <Ionicons name="create-outline" size={26} color="#2563EB" />
           </TouchableOpacity>
 
-          <TouchableOpacity onPress={() => console.log("Toggle Pause/Resume", taskId)}>
+          <TouchableOpacity onPress={() => updateStatus({ taskId, action: isActive ? 'pause' : 'activate' })}>
             <Ionicons
               name={isActive ? "pause-circle" : "play-circle"}
               size={26}
@@ -72,7 +73,7 @@ export default function TaskDetailsScreen({ route, navigation }: Props) {
             />
           </TouchableOpacity>
 
-          <TouchableOpacity onPress={() => console.log("Archive task", taskId)}>
+          <TouchableOpacity onPress={() => updateStatus({ taskId, action: 'archive' })}>
             <Ionicons name="archive-outline" size={26} color="#EF4444" />
           </TouchableOpacity>
         </View>

--- a/frontend/app/screens/admin/TasksManagementScreen.tsx
+++ b/frontend/app/screens/admin/TasksManagementScreen.tsx
@@ -7,13 +7,14 @@ import TaskCard from "../../components/admin/TaskCard";
 import ScreenHeaderLayout from "../../components/layout/ScreenHeaderLayout";
 import { useThemeStore } from '../../stores/themeStore';
 import { API_ENDPOINTS } from '../../api/apiEndpoints';
-import { useAdminTasks } from "../../api/queries";
+import { useAdminTasks, useUpdateTaskStatus } from "../../api/queries";
 
 
 export default function TasksManagementScreen({ navigation }: any) {
   const { theme } = useThemeStore();
   const themeColors = Colors[theme as keyof typeof Colors];
   const { data: tasks = [], isLoading } = useAdminTasks();
+  const { mutate: updateStatus } = useUpdateTaskStatus();
 
   return (
     <ScreenHeaderLayout
@@ -42,10 +43,10 @@ export default function TasksManagementScreen({ navigation }: any) {
                 })
               }
               onToggleStatus={() => {
-                // PATCH /tasks/{id}/status
+                updateStatus({ taskId: item.taskId, action: item.status === 'ACTIVE' ? 'pause' : 'activate' });
               }}
               onArchive={() => {
-                // confirm + archive
+                updateStatus({ taskId: item.taskId, action: 'archive' });
               }}
             />
           )}


### PR DESCRIPTION
Resolves #176 
**Changes Made:**
- Added missing `PAUSE_TASK`, `ARCHIVE_TASK`, and `ACTIVATE_TASK` backend routes to `apiEndpoints.ts`.
- Created a `useUpdateTaskStatus` React Query mutation hook in `queries.ts` to handle status API calls and auto-invalidate the `dashboardTasks` cache.
- Replaced placeholder `console.log` statements in `TaskDetailsScreen.tsx` and `TasksManagementScreen.tsx` with calls to the new mutation.
- The Play/Pause icon now dynamically toggles between `pause` and `activate` endpoints based on the current state of the task.
