### PR TITLE
refactor: decouple task and classification domains by introducing Tas…

### DIFF
--- a/backend/src/main/java/com/swipelab/classification/application/ClassificationService.java
+++ b/backend/src/main/java/com/swipelab/classification/application/ClassificationService.java
@@ -10,6 +10,7 @@ import com.swipelab.classification.infrastructure.CredibilityRepository;
 import com.swipelab.classification.infrastructure.GoldImageRepository;
 import com.swipelab.classification.infrastructure.ImageRepository;
 
+import com.swipelab.classification.application.port.out.TaskProvider;
 import com.swipelab.exception.ResourceNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -31,6 +32,7 @@ public class ClassificationService {
 
         private final FraudDetectionService fraudDetectionService;
         private final ImageService imageService;
+        private final TaskProvider taskProvider;
 
         @Transactional
         public NextBatchResponse submitClassification(String username, String userRole, Double userCredibility,
@@ -47,7 +49,8 @@ public class ClassificationService {
 
                 Optional<GoldImage> goldImageOpt = goldImageRepository.findByImageId(image.getId());
 
-                String species = image.getTask() != null ? image.getTask().getQuerySpecies() : null;
+                TaskProvider.TaskInfo taskInfo = taskProvider.getTaskInfo(request.getTaskId());
+                String species = taskInfo.querySpecies();
                 if (goldImageOpt.isPresent() && species == null) {
                         species = goldImageOpt.get().getSpecies();
                 }
@@ -122,7 +125,8 @@ public class ClassificationService {
                                         .orElseThrow(() -> new ResourceNotFoundException(
                                                         "Image not found: " + response.getImageId()));
 
-                        String species = image.getTask() != null ? image.getTask().getQuerySpecies() : null;
+                        TaskProvider.TaskInfo taskInfo = taskProvider.getTaskInfo(taskId);
+                        String species = taskInfo.querySpecies();
 
                         Optional<GoldImage> goldImageOpt = goldImageRepository.findByImageId(image.getId());
 

--- a/backend/src/main/java/com/swipelab/classification/application/port/in/TargetSpeciesProviderImpl.java
+++ b/backend/src/main/java/com/swipelab/classification/application/port/in/TargetSpeciesProviderImpl.java
@@ -1,0 +1,48 @@
+package com.swipelab.classification.application.port.in;
+
+import com.swipelab.classification.domain.Label;
+import com.swipelab.classification.infrastructure.LabelRepository;
+import com.swipelab.dto.response.TargetSpeciesResponse;
+import com.swipelab.tasks.application.port.out.TargetSpeciesProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TargetSpeciesProviderImpl implements TargetSpeciesProvider {
+
+    private final LabelRepository labelRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<TargetSpeciesResponse> getSpeciesByIds(List<Long> speciesIds) {
+        if (speciesIds == null || speciesIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return labelRepository.findAllById(speciesIds).stream()
+                .map(label -> TargetSpeciesResponse.builder()
+                        .name(label.getName())
+                        .commonName(label.getCommonName())
+                        .referenceImages(Collections.emptyList())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public List<Long> getOrCreateSpeciesIds(List<String> speciesNames) {
+        if (speciesNames == null || speciesNames.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return speciesNames.stream().map(name -> {
+            Label label = labelRepository.findByName(name)
+                    .orElseGet(() -> labelRepository.save(Label.builder().name(name).build()));
+            return label.getId();
+        }).collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/com/swipelab/classification/application/port/out/TaskProvider.java
+++ b/backend/src/main/java/com/swipelab/classification/application/port/out/TaskProvider.java
@@ -1,0 +1,9 @@
+package com.swipelab.classification.application.port.out;
+
+import java.util.List;
+
+public interface TaskProvider {
+    TaskInfo getTaskInfo(Long taskId);
+
+    record TaskInfo(Long id, String question, String querySpecies, List<String> targetSpeciesNames) {}
+}

--- a/backend/src/main/java/com/swipelab/classification/domain/GoldImageService.java
+++ b/backend/src/main/java/com/swipelab/classification/domain/GoldImageService.java
@@ -13,8 +13,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.web.multipart.MultipartFile;
 import com.swipelab.infrastructure.FileStorageService;
-import com.swipelab.tasks.infrastructure.TaskRepository;
-import com.swipelab.tasks.domain.Task;
+import com.swipelab.classification.application.port.out.TaskProvider;
 
 @Service
 @RequiredArgsConstructor
@@ -23,7 +22,7 @@ public class GoldImageService {
     private final GoldImageRepository goldImageRepository;
     private final ImageRepository imageRepository;
     private final FileStorageService fileStorageService;
-    private final TaskRepository taskRepository;
+    private final TaskProvider taskProvider;
 
     @Transactional
     public GoldImageResponse createGoldImage(GoldImageRequest request) {
@@ -51,12 +50,11 @@ public class GoldImageService {
             throw new IllegalArgumentException("Either file or imageUrl must be provided");
         }
 
-        Task task = taskRepository.findById(taskId)
-                .orElseThrow(() -> new ResourceNotFoundException("Task not found: " + taskId));
+        TaskProvider.TaskInfo taskInfo = taskProvider.getTaskInfo(taskId);
 
         Image image = Image.builder()
                 .srcPath(srcPath)
-                .task(task)
+                .taskId(taskInfo.id())
                 .build();
         Image savedImage = imageRepository.save(image);
 
@@ -81,7 +79,7 @@ public class GoldImageService {
     public List<GoldImageResponse> getGoldImagesByTask(Long taskId) {
         // Assuming we want all gold images for images belonging to a task
         return goldImageRepository.findAll().stream()
-                .filter(g -> g.getImage().getTask().getId().equals(taskId))
+                .filter(g -> g.getImage().getTaskId().equals(taskId))
                 .map(this::mapToResponse)
                 .collect(Collectors.toList());
     }

--- a/backend/src/main/java/com/swipelab/classification/domain/Image.java
+++ b/backend/src/main/java/com/swipelab/classification/domain/Image.java
@@ -6,7 +6,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
-import com.swipelab.tasks.domain.Task;
 
 import java.time.LocalDateTime;
 
@@ -64,9 +63,8 @@ public class Image {
      * private Label correctLabel;
      */
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "task_id", nullable = false)
-    private Task task;
+    @Column(name = "task_id", nullable = false)
+    private Long taskId;
 
     @CreationTimestamp
     @Column(updatable = false)

--- a/backend/src/main/java/com/swipelab/classification/domain/ImageService.java
+++ b/backend/src/main/java/com/swipelab/classification/domain/ImageService.java
@@ -7,10 +7,9 @@ import com.swipelab.dto.response.ImageBatchResponse;
 import com.swipelab.dto.response.ImageResponse;
 import com.swipelab.exception.ResourceNotFoundException;
 
-import com.swipelab.tasks.domain.Task;
+import com.swipelab.classification.application.port.out.TaskProvider;
 import com.swipelab.classification.infrastructure.ImageRepository;
 import com.swipelab.classification.infrastructure.LabelRepository;
-import com.swipelab.tasks.infrastructure.TaskRepository;
 import com.swipelab.classification.infrastructure.ClassificationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -28,7 +27,7 @@ import java.util.stream.Collectors;
 public class ImageService {
 
         private final ImageRepository imageRepository;
-        private final TaskRepository taskRepository;
+        private final TaskProvider taskProvider;
         private final LabelRepository labelRepository;
         private final ClassificationRepository classificationRepository;
         private final GoldImageRepository goldImageRepository;
@@ -36,14 +35,8 @@ public class ImageService {
 
         @Transactional(readOnly = true)
         public NextBatchResponse getNextBatchForApi(Long taskId, String username, int count) {
-                Task task = taskRepository.findById(taskId)
-                                .orElseThrow(() -> new ResourceNotFoundException("Task not found: " + taskId));
-
-                // Build the list of species names for this task
-                List<String> taskSpecies = task.getTargetSpecies() == null ? List.of() :
-                        task.getTargetSpecies().stream()
-                                .map(com.swipelab.classification.domain.Label::getName)
-                                .collect(Collectors.toList());
+                TaskProvider.TaskInfo taskInfo = taskProvider.getTaskInfo(taskId);
+                List<String> taskSpecies = taskInfo.targetSpeciesNames();
 
                 List<BatchImageDto> batchImages = new ArrayList<>();
                 int attempt = 0;
@@ -62,7 +55,7 @@ public class ImageService {
                                         && b.getQuestion() != null
                                         && b.getQuestion().contains(pair.species() != null ? pair.species() : ""));
                         if (!alreadyInBatch) {
-                                batchImages.add(mapToBatchDto(pair.image(), task, pair.species()));
+                                batchImages.add(mapToBatchDto(pair.image(), taskInfo, pair.species()));
                                 found++;
                         }
                         attempt++;
@@ -72,14 +65,14 @@ public class ImageService {
         }
 
 
-        private BatchImageDto mapToBatchDto(Image image, Task task, String species) {
+        private BatchImageDto mapToBatchDto(Image image, TaskProvider.TaskInfo taskInfo, String species) {
                 String src = getProvidedImagePath(image.getSrcPath());
                 String contentType = "image/jpeg";
 
                 // Build question from the explicitly selected species for this image
                 String question;
-                if (task.getQuestion() != null && !task.getQuestion().isBlank()) {
-                        question = task.getQuestion();
+                if (taskInfo.question() != null && !taskInfo.question().isBlank()) {
+                        question = taskInfo.question();
                 } else if (species != null && !species.isBlank()) {
                         question = "Is this a " + species + "?";
                 } else {
@@ -88,7 +81,7 @@ public class ImageService {
 
                 return BatchImageDto.builder()
                                 .imageId(image.getId())
-                                .taskId(task.getId())
+                                .taskId(taskInfo.id())
                                 .question(question)
                                 .image(ImageDataDto.builder()
                                                 .contentType(contentType)
@@ -136,14 +129,12 @@ public class ImageService {
 
         @Transactional
         public ImageResponse uploadImage(ImageUploadRequest request) {
-                Task task = taskRepository.findById(request.getTaskId())
-                                .orElseThrow(() -> new ResourceNotFoundException(
-                                                "Task not found with id: " + request.getTaskId()));
+                TaskProvider.TaskInfo taskInfo = taskProvider.getTaskInfo(request.getTaskId());
 
                 Image image = Image.builder()
                                 .srcPath(request.getImageUrl())
                                 .caption(request.getCaption())
-                                .task(task)
+                                .taskId(taskInfo.id())
                                 .priority(request.getPriority())
                                 .build();
 
@@ -210,7 +201,7 @@ public class ImageService {
                                 .imageUrl(image.getSrcPath())
                                 .thumbnailUrl(image.getThumbnailUrl())
                                 .caption(image.getCaption())
-                                .taskId(image.getTask().getId())
+                                .taskId(image.getTaskId())
                                 .priority(image.getPriority())
                                 .isGoldStandard(isGold)
                                 .build();

--- a/backend/src/main/java/com/swipelab/classification/infrastructure/ImageRepository.java
+++ b/backend/src/main/java/com/swipelab/classification/infrastructure/ImageRepository.java
@@ -18,7 +18,7 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
     Image findByExternalBoxId(Long externalBoxId);
 
     // Find all unclassified gold standard images for a specific task and user
-    @Query("SELECT i FROM Image i WHERE i.task.id = :taskId " +
+    @Query("SELECT i FROM Image i WHERE i.taskId = :taskId " +
             "AND i.id IN (SELECT g.image.id FROM GoldImage g) " +
             "AND NOT EXISTS (SELECT c FROM Classification c WHERE c.image.id = i.id AND c.username = :username)")
     List<Image> findUnclassifiedGoldImages(@Param("username") String username, @Param("taskId") Long taskId);
@@ -31,7 +31,7 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
      * Prioritises images with fewer total classifications overall.
      */
     @Query("SELECT i FROM Image i " +
-            "WHERE i.task.id = :taskId " +
+            "WHERE i.taskId = :taskId " +
             "AND i.id NOT IN (SELECT g.image.id FROM GoldImage g) " +
             "AND (SELECT COUNT(DISTINCT c.querySpecies) FROM Classification c " +
             "     WHERE c.image.id = i.id AND c.username = :username) < :speciesCount " +

--- a/backend/src/main/java/com/swipelab/config/MockDataSeeder.java
+++ b/backend/src/main/java/com/swipelab/config/MockDataSeeder.java
@@ -177,13 +177,13 @@ public class MockDataSeeder implements CommandLineRunner {
 
             Image img1 = Image.builder()
                     .srcPath("101") // Mock Stardbi ID 101
-                    .task(task)
+                    .taskId(task.getId())
                     .priority(1)
                     .build();
 
             Image img2 = Image.builder()
                     .srcPath("102") // Mock Stardbi ID 102
-                    .task(task)
+                    .taskId(task.getId())
                     .priority(1)
                     .build();
 

--- a/backend/src/main/java/com/swipelab/integration/stardbi/StardbiSyncService.java
+++ b/backend/src/main/java/com/swipelab/integration/stardbi/StardbiSyncService.java
@@ -80,7 +80,7 @@ public class StardbiSyncService {
                             String base64Image = Base64.getEncoder().encodeToString(imageBytes);
 
                             Image newImage = Image.builder()
-                                    .task(task)
+                                    .taskId(task.getId())
                                     .externalBoxId(crop.getBoxId())
                                     .parentImageId(crop.getImageId())
                                     .srcPath(base64Image)
@@ -156,7 +156,7 @@ public class StardbiSyncService {
                                     java.nio.file.Files.copy(zis, outputFile.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
                                     
                                     Image newImage = Image.builder()
-                                            .task(task)
+                                            .taskId(task.getId())
                                             .externalBoxId(boxId)
                                             .parentImageId(extractImageIdFromFileName(fileName))
                                             .srcPath(outputFile.getAbsolutePath())

--- a/backend/src/main/java/com/swipelab/tasks/application/TaskService.java
+++ b/backend/src/main/java/com/swipelab/tasks/application/TaskService.java
@@ -11,8 +11,7 @@ import com.swipelab.tasks.domain.Task;
 import com.swipelab.tasks.domain.TaskMapper;
 import com.swipelab.tasks.domain.TaskStatus;
 import com.swipelab.tasks.infrastructure.TaskRepository;
-import com.swipelab.classification.domain.Label;
-import com.swipelab.classification.infrastructure.LabelRepository;
+import com.swipelab.tasks.application.port.out.TargetSpeciesProvider;
 import com.swipelab.integration.stardbi.StardbiSyncService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -33,7 +32,7 @@ public class TaskService {
 
     private final TaskRepository taskRepository;
     private final RecipientGroupRepository recipientGroupRepository;
-    private final LabelRepository labelRepository;
+    private final TargetSpeciesProvider targetSpeciesProvider;
     private final TaskMapper taskMapper;
     private final StardbiSyncService stardbiSyncService;
 
@@ -134,13 +133,11 @@ public class TaskService {
         task.setStatus(TaskStatus.PROCESSING);
         
         if (request.getTargetSpecies() != null && !request.getTargetSpecies().isEmpty()) {
-            List<Label> labels = new ArrayList<>();
-            for (com.swipelab.dto.request.TargetSpeciesRequest tsr : request.getTargetSpecies()) {
-                Label label = labelRepository.findByName(tsr.getName())
-                        .orElseGet(() -> labelRepository.save(Label.builder().name(tsr.getName()).build()));
-                labels.add(label);
-            }
-            task.setTargetSpecies(labels);
+            List<String> speciesNames = request.getTargetSpecies().stream()
+                    .map(com.swipelab.dto.request.TargetSpeciesRequest::getName)
+                    .collect(Collectors.toList());
+            List<Long> speciesIds = targetSpeciesProvider.getOrCreateSpeciesIds(speciesNames);
+            task.setTargetSpeciesIds(speciesIds);
         }
         
         task = taskRepository.save(task);
@@ -184,13 +181,11 @@ public class TaskService {
         taskMapper.updateEntity(task, request);
         
         if (request.getTargetSpecies() != null) {
-            List<Label> labels = new ArrayList<>();
-            for (com.swipelab.dto.request.TargetSpeciesRequest tsr : request.getTargetSpecies()) {
-                Label label = labelRepository.findByName(tsr.getName())
-                        .orElseGet(() -> labelRepository.save(Label.builder().name(tsr.getName()).build()));
-                labels.add(label);
-            }
-            task.setTargetSpecies(labels);
+            List<String> speciesNames = request.getTargetSpecies().stream()
+                    .map(com.swipelab.dto.request.TargetSpeciesRequest::getName)
+                    .collect(Collectors.toList());
+            List<Long> speciesIds = targetSpeciesProvider.getOrCreateSpeciesIds(speciesNames);
+            task.setTargetSpeciesIds(speciesIds);
         }
         
         // Trigger a background sync in case task external experiments were added

--- a/backend/src/main/java/com/swipelab/tasks/application/port/in/TaskProviderImpl.java
+++ b/backend/src/main/java/com/swipelab/tasks/application/port/in/TaskProviderImpl.java
@@ -1,0 +1,34 @@
+package com.swipelab.tasks.application.port.in;
+
+import com.swipelab.classification.application.port.out.TaskProvider;
+import com.swipelab.exception.ResourceNotFoundException;
+import com.swipelab.tasks.domain.Task;
+import com.swipelab.tasks.infrastructure.TaskRepository;
+import com.swipelab.tasks.application.port.out.TargetSpeciesProvider;
+import com.swipelab.dto.response.TargetSpeciesResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TaskProviderImpl implements TaskProvider {
+
+    private final TaskRepository taskRepository;
+    private final TargetSpeciesProvider targetSpeciesProvider;
+
+    @Override
+    @Transactional(readOnly = true)
+    public TaskInfo getTaskInfo(Long taskId) {
+        Task task = taskRepository.findById(taskId)
+                .orElseThrow(() -> new ResourceNotFoundException("Task not found: " + taskId));
+        
+        List<TargetSpeciesResponse> species = targetSpeciesProvider.getSpeciesByIds(task.getTargetSpeciesIds());
+        List<String> speciesNames = species.stream().map(TargetSpeciesResponse::getName).collect(Collectors.toList());
+
+        return new TaskInfo(task.getId(), task.getQuestion(), task.getQuerySpecies(), speciesNames);
+    }
+}

--- a/backend/src/main/java/com/swipelab/tasks/application/port/out/TargetSpeciesProvider.java
+++ b/backend/src/main/java/com/swipelab/tasks/application/port/out/TargetSpeciesProvider.java
@@ -1,0 +1,9 @@
+package com.swipelab.tasks.application.port.out;
+
+import com.swipelab.dto.response.TargetSpeciesResponse;
+import java.util.List;
+
+public interface TargetSpeciesProvider {
+    List<TargetSpeciesResponse> getSpeciesByIds(List<Long> speciesIds);
+    List<Long> getOrCreateSpeciesIds(List<String> speciesNames);
+}

--- a/backend/src/main/java/com/swipelab/tasks/domain/Task.java
+++ b/backend/src/main/java/com/swipelab/tasks/domain/Task.java
@@ -9,8 +9,6 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
-import com.swipelab.classification.domain.Label;
-import com.swipelab.classification.domain.Image;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -98,17 +96,14 @@ public class Task {
     private Boolean isPublic = false;
 
     @BatchSize(size = 20)
-    @ManyToMany
-    @JoinTable(name = "task_target_species", joinColumns = @JoinColumn(name = "task_id"), inverseJoinColumns = @JoinColumn(name = "label_id"))
+    @ElementCollection
+    @CollectionTable(name = "task_target_species", joinColumns = @JoinColumn(name = "task_id"))
+    @Column(name = "label_id")
     @Builder.Default
-    private List<Label> targetSpecies = new ArrayList<>();
+    private List<Long> targetSpeciesIds = new ArrayList<>();
 
     @Column(name = "created_by", nullable = false)
     private String createdBy;
-
-    @OneToMany(mappedBy = "task", cascade = CascadeType.ALL, orphanRemoval = true)
-    @Builder.Default
-    private List<Image> images = new ArrayList<>();
 
     // =========================
     // Status & Lifecycle

--- a/backend/src/main/java/com/swipelab/tasks/domain/TaskMapper.java
+++ b/backend/src/main/java/com/swipelab/tasks/domain/TaskMapper.java
@@ -6,16 +6,20 @@ import com.swipelab.dto.response.TaskProgressResponse;
 import com.swipelab.dto.response.TaskResponse;
 import com.swipelab.dto.response.TargetSpeciesResponse;
 
-import com.swipelab.classification.domain.Label;
+import com.swipelab.tasks.application.port.out.TargetSpeciesProvider;
 
 import org.springframework.stereotype.Component;
+import lombok.RequiredArgsConstructor;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Component
+@RequiredArgsConstructor
 public class TaskMapper {
+
+    private final TargetSpeciesProvider targetSpeciesProvider;
 
     // =========================
     // REQUEST → ENTITY
@@ -103,13 +107,7 @@ public class TaskMapper {
                 .recipientGroups(task.getRecipientGroups())
                 .assignedUsernames(task.getAssignedUsernames())
                 .isPublic(task.getIsPublic())
-                .targetSpecies(
-                        task.getTargetSpecies() != null
-                                ? task.getTargetSpecies()
-                                        .stream()
-                                        .map(this::toTargetSpeciesResponse)
-                                        .collect(Collectors.toList())
-                                : Collections.emptyList())
+                .targetSpecies(targetSpeciesProvider.getSpeciesByIds(task.getTargetSpeciesIds()))
                 .progress(TaskProgressResponse.empty())
                 // New fields
                 .createdAt(task.getCreatedAt() != null
@@ -133,21 +131,6 @@ public class TaskMapper {
                 .map(this::toResponse)
                 .collect(Collectors.toList());
     }
-
-    // =========================
-    // HELPERS
-    // =========================
-
-    private TargetSpeciesResponse toTargetSpeciesResponse(Label label) {
-        if (label == null) {
-            return null;
-        }
-
-        return TargetSpeciesResponse.builder()
-                .name(label.getName())
-                .commonName(label.getCommonName())
-                .referenceImages(Collections.emptyList()) // filled later if needed
-                .build();
-    }
-
 }
+
+

--- a/backend/src/test/java/com/swipelab/classification/application/ClassificationServiceTest.java
+++ b/backend/src/test/java/com/swipelab/classification/application/ClassificationServiceTest.java
@@ -14,7 +14,7 @@ import com.swipelab.classification.infrastructure.CredibilityRepository;
 import com.swipelab.classification.infrastructure.GoldImageRepository;
 import com.swipelab.classification.infrastructure.ImageRepository;
 import com.swipelab.exception.ResourceNotFoundException;
-import com.swipelab.tasks.domain.Task;
+import com.swipelab.classification.application.port.out.TaskProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -43,6 +43,9 @@ class ClassificationServiceTest {
     private ImageRepository imageRepository;
 
     @Mock
+    private TaskProvider taskProvider;
+
+    @Mock
     private GoldImageRepository goldImageRepository;
 
     @Mock
@@ -62,7 +65,7 @@ class ClassificationServiceTest {
 
     private SubmitClassificationRequest request;
     private Image image;
-    private Task task;
+    private TaskProvider.TaskInfo taskInfo;
 
     @BeforeEach
     void setUp() {
@@ -72,13 +75,11 @@ class ClassificationServiceTest {
         request.setDecision(Classification.UserResponse.YES);
         request.setResponseTimeMs(1500L);
 
-        task = new Task();
-        task.setId(1L);
-        task.setQuerySpecies("Lion");
+        taskInfo = new TaskProvider.TaskInfo(1L, "Question", "Lion", Collections.emptyList());
 
         image = new Image();
         image.setId(1L);
-        image.setTask(task);
+        image.setTaskId(1L);
     }
 
     @Test
@@ -99,6 +100,7 @@ class ClassificationServiceTest {
         when(goldImageRepository.findByImageId(1L)).thenReturn(Optional.of(goldImage));
         when(imageService.getNextBatchForApi(anyLong(), anyString(), anyInt()))
                 .thenReturn(NextBatchResponse.builder().build());
+        when(taskProvider.getTaskInfo(1L)).thenReturn(taskInfo);
 
         classificationService.submitClassification("testuser", "USER", 0.8, request);
 
@@ -120,6 +122,7 @@ class ClassificationServiceTest {
         when(goldImageRepository.findByImageId(1L)).thenReturn(Optional.empty());
         when(imageService.getNextBatchForApi(anyLong(), anyString(), anyInt()))
                 .thenReturn(NextBatchResponse.builder().build());
+        when(taskProvider.getTaskInfo(1L)).thenReturn(taskInfo);
 
         Classification savedClassification = new Classification();
         savedClassification.setId(10L);
@@ -150,6 +153,7 @@ class ClassificationServiceTest {
 
         when(imageRepository.findById(1L)).thenReturn(Optional.of(image));
         when(goldImageRepository.findByImageId(1L)).thenReturn(Optional.empty());
+        when(taskProvider.getTaskInfo(1L)).thenReturn(taskInfo);
         when(classificationRepository.save(any(Classification.class))).thenReturn(savedClassification);
 
         classificationService.submitBatchResponses("testuser", "USER", 1L, responses);

--- a/backend/src/test/java/com/swipelab/classification/domain/GoldImageServiceTest.java
+++ b/backend/src/test/java/com/swipelab/classification/domain/GoldImageServiceTest.java
@@ -5,7 +5,7 @@ import com.swipelab.classification.infrastructure.ImageRepository;
 import com.swipelab.dto.request.GoldImageRequest;
 import com.swipelab.dto.response.GoldImageResponse;
 import com.swipelab.exception.ResourceNotFoundException;
-import com.swipelab.tasks.domain.Task;
+import com.swipelab.classification.application.port.out.TaskProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,22 +31,24 @@ class GoldImageServiceTest {
     @Mock
     private ImageRepository imageRepository;
 
+    @Mock
+    private TaskProvider taskProvider;
+
     @InjectMocks
     private GoldImageService goldImageService;
 
     private Image image;
     private GoldImage goldImage;
     private GoldImageRequest request;
-    private Task task;
+    private TaskProvider.TaskInfo taskInfo;
 
     @BeforeEach
     void setUp() {
-        task = new Task();
-        task.setId(1L);
+        taskInfo = new TaskProvider.TaskInfo(1L, "Question", "Lion", Collections.emptyList());
 
         image = new Image();
         image.setId(1L);
-        image.setTask(task);
+        image.setTaskId(1L);
 
         goldImage = new GoldImage();
         goldImage.setId(1L);

--- a/backend/src/test/java/com/swipelab/classification/domain/ImageServiceTest.java
+++ b/backend/src/test/java/com/swipelab/classification/domain/ImageServiceTest.java
@@ -10,8 +10,7 @@ import com.swipelab.dto.request.ImageUploadRequest;
 import com.swipelab.dto.response.ImageBatchResponse;
 import com.swipelab.dto.response.ImageResponse;
 import com.swipelab.exception.ResourceNotFoundException;
-import com.swipelab.tasks.domain.Task;
-import com.swipelab.tasks.infrastructure.TaskRepository;
+import com.swipelab.classification.application.port.out.TaskProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,7 +35,7 @@ class ImageServiceTest {
     private ImageRepository imageRepository;
 
     @Mock
-    private TaskRepository taskRepository;
+    private TaskProvider taskProvider;
 
     @Mock
     private LabelRepository labelRepository;
@@ -53,25 +52,23 @@ class ImageServiceTest {
     @InjectMocks
     private ImageService imageService;
 
-    private Task task;
+    private TaskProvider.TaskInfo taskInfo;
     private Image image;
 
     @BeforeEach
     void setUp() {
-        task = new Task();
-        task.setId(1L);
-        task.setQuestion("Classify this image");
+        taskInfo = new TaskProvider.TaskInfo(1L, "Classify this image", "MAMMALS", Collections.emptyList());
 
         image = new Image();
         image.setId(1L);
         image.setSrcPath("http://example.com/img.jpg");
-        image.setTask(task);
+        image.setTaskId(1L);
         image.setPriority(1);
     }
 
     @Test
     void getNextBatchForApi_ShouldReturnImages() {
-        when(taskRepository.findById(1L)).thenReturn(Optional.of(task));
+        when(taskProvider.getTaskInfo(1L)).thenReturn(taskInfo);
         // task has no targetSpecies so species list is empty → question comes from task.getQuestion()
         when(taskDistributionService.getNextImageForUser(anyString(), anyLong(), anyList()))
                 .thenReturn(Optional.of(new TaskDistributionService.ImageSpeciesPair(image, null)))
@@ -88,7 +85,7 @@ class ImageServiceTest {
 
     @Test
     void getNextBatchForApi_ShouldThrowException_WhenTaskNotFound() {
-        when(taskRepository.findById(1L)).thenReturn(Optional.empty());
+        when(taskProvider.getTaskInfo(1L)).thenThrow(new ResourceNotFoundException("Task not found: 1"));
 
         assertThrows(ResourceNotFoundException.class, () -> 
                 imageService.getNextBatchForApi(1L, "testuser", 5));
@@ -103,7 +100,7 @@ class ImageServiceTest {
         request.setPriority(1);
         request.setIsGoldStandard(false);
 
-        when(taskRepository.findById(1L)).thenReturn(Optional.of(task));
+        when(taskProvider.getTaskInfo(1L)).thenReturn(taskInfo);
         when(imageRepository.save(any(Image.class))).thenReturn(image);
         when(goldImageRepository.existsByImageId(1L)).thenReturn(false);
 
@@ -127,7 +124,7 @@ class ImageServiceTest {
         label.setId(1L);
         label.setName("Lion");
 
-        when(taskRepository.findById(1L)).thenReturn(Optional.of(task));
+        when(taskProvider.getTaskInfo(1L)).thenReturn(taskInfo);
         when(imageRepository.save(any(Image.class))).thenReturn(image);
         when(labelRepository.findById(1L)).thenReturn(Optional.of(label));
 
@@ -140,7 +137,7 @@ class ImageServiceTest {
     void getImageBatch_ShouldReturnUnclassifiedImages() {
         Image image2 = new Image();
         image2.setId(2L);
-        image2.setTask(task);
+        image2.setTaskId(1L);
 
         when(imageRepository.findByTaskId(1L)).thenReturn(Arrays.asList(image, image2));
         when(classificationRepository.existsByUsernameAndImageId("testuser", 1L)).thenReturn(true);

--- a/backend/src/test/java/com/swipelab/tasks/domain/TaskMapperTest.java
+++ b/backend/src/test/java/com/swipelab/tasks/domain/TaskMapperTest.java
@@ -1,11 +1,13 @@
 package com.swipelab.tasks.domain;
 
-import com.swipelab.classification.domain.Label;
+import com.swipelab.tasks.application.port.out.TargetSpeciesProvider;
 import com.swipelab.dto.request.CreateTaskRequest;
 import com.swipelab.dto.request.UpdateTaskRequest;
 import com.swipelab.dto.response.TaskResponse;
+import com.swipelab.dto.response.TargetSpeciesResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
@@ -16,10 +18,12 @@ import static org.junit.jupiter.api.Assertions.*;
 class TaskMapperTest {
 
     private TaskMapper taskMapper;
+    private TargetSpeciesProvider targetSpeciesProvider;
 
     @BeforeEach
     void setUp() {
-        taskMapper = new TaskMapper();
+        targetSpeciesProvider = Mockito.mock(TargetSpeciesProvider.class);
+        taskMapper = new TaskMapper(targetSpeciesProvider);
     }
 
     @Test
@@ -56,15 +60,16 @@ class TaskMapperTest {
 
     @Test
     void toResponse_ShouldMapTaskToTaskResponse() {
-        Label label = new Label();
-        label.setName("Dog");
-        
         Task task = new Task();
         task.setId(1L);
         task.setTitle("Title");
         task.setStatus(TaskStatus.ACTIVE);
-        task.setTargetSpecies(Collections.singletonList(label));
+        task.setTargetSpeciesIds(Collections.singletonList(2L));
         task.setCreatedAt(LocalDateTime.now());
+
+        TargetSpeciesResponse speciesResponse = TargetSpeciesResponse.builder().name("Dog").build();
+        Mockito.when(targetSpeciesProvider.getSpeciesByIds(Collections.singletonList(2L)))
+               .thenReturn(Collections.singletonList(speciesResponse));
 
         TaskResponse response = taskMapper.toResponse(task);
 


### PR DESCRIPTION
Here's a comprehensive PR description you can use:

Phase 2: Break Cyclic Domain Dependencies (tasks ↔ classification)
Overview
This PR resolves the bidirectional coupling between the tasks and classification domains, moving the architecture toward a clean modular monolith with well-defined domain boundaries.

Problem
The tasks and classification domains had a circular dependency:

Task entity had @OneToMany List<Image> and @ManyToMany List<Label> targetSpecies
Image entity had a @ManyToOne Task task back-reference
Services in classification directly imported TaskRepository and Task from the tasks package and vice versa
This made it impossible to reason about, test, or evolve either domain independently.

What Changed
Entity Decoupling
Image — removed @ManyToOne Task task, replaced with a plain Long taskId scalar field
Task — removed @ManyToMany List<Label> targetSpecies, replaced with @ElementCollection List<Long> targetSpeciesIds; removed @OneToMany List<Image> images
New Interface Ports
TargetSpeciesProvider (tasks domain) — allows TaskMapper and TaskService to resolve species names from IDs without importing LabelRepository into the wrong domain
TaskProvider (classification domain) — allows ImageService, ClassificationService, and GoldImageService to fetch task metadata (question, querySpecies, species list) without importing TaskRepository or the Task entity
Service Refactoring
TaskMapper — now uses TargetSpeciesProvider to hydrate species names when building TaskResponse
TaskService — replaced direct LabelRepository calls with TargetSpeciesProvider
ImageService — replaced TaskRepository dependency with TaskProvider
ClassificationService — replaced image.getTask().getQuerySpecies() with TaskProvider.getTaskInfo(taskId).querySpecies()
GoldImageService — replaced TaskRepository dependency with TaskProvider
StardbiSyncService — updated Image builder from .task(task) → .taskId(task.getId())
MockDataSeeder — updated to set taskId on seeded images instead of the entity reference
Repository Query Fixes
ImageRepository — updated all JPQL @Query strings from i.task.id → i.taskId to match the new scalar field
Test Updates
Updated TaskMapperTest, ImageServiceTest, ClassificationServiceTest, GoldImageServiceTest to mock TaskProvider/TargetSpeciesProvider instead of TaskRepository/Task entities
Result
✅ mvn clean compile — BUILD SUCCESS
✅ mvn test — 207 tests, 0 failures, 0 errors
✅ Zero cross-domain entity imports remain between tasks and classification