### PR TITLE
refactor: extract gold image evaluation logic from ClassificationServ…

### DIFF
--- a/backend/src/main/java/com/swipelab/classification/application/ClassificationService.java
+++ b/backend/src/main/java/com/swipelab/classification/application/ClassificationService.java
@@ -1,15 +1,15 @@
 package com.swipelab.classification.application;
 
-import com.swipelab.classification.domain.*;
+import com.swipelab.classification.domain.Classification;
+import com.swipelab.classification.domain.FraudDetectionService;
+import com.swipelab.classification.domain.Image;
+import com.swipelab.classification.domain.ImageService;
 import com.swipelab.classification.dto.UserClassification;
 import com.swipelab.classification.dto.api.NextBatchResponse;
 import com.swipelab.classification.dto.api.SubmitClassificationRequest;
 import com.swipelab.classification.events.ClassificationSubmittedEvent;
 import com.swipelab.classification.infrastructure.ClassificationRepository;
-import com.swipelab.classification.infrastructure.CredibilityRepository;
-import com.swipelab.classification.infrastructure.GoldImageRepository;
 import com.swipelab.classification.infrastructure.ImageRepository;
-
 import com.swipelab.classification.application.port.out.TaskProvider;
 import com.swipelab.exception.ResourceNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +17,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -24,170 +25,129 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class ClassificationService {
 
-        private final ClassificationRepository classificationRepository;
-        private final ImageRepository imageRepository;
-        private final GoldImageRepository goldImageRepository;
-        private final CredibilityRepository credibilityRepository;
-        private final ApplicationEventPublisher eventPublisher;
+    private final ClassificationRepository classificationRepository;
+    private final ImageRepository imageRepository;
+    private final ApplicationEventPublisher eventPublisher;
+    private final FraudDetectionService fraudDetectionService;
+    private final ImageService imageService;
+    private final TaskProvider taskProvider;
+    private final GoldImageEvaluatorService goldImageEvaluatorService;
 
-        private final FraudDetectionService fraudDetectionService;
-        private final ImageService imageService;
-        private final TaskProvider taskProvider;
+    @Transactional
+    public NextBatchResponse submitClassification(String username, String userRole, Double userCredibility,
+            SubmitClassificationRequest request) {
 
-        @Transactional
-        public NextBatchResponse submitClassification(String username, String userRole, Double userCredibility,
-                        SubmitClassificationRequest request) {
-                // 1. Analyze Fraud (Response Time)
-                if (request.getResponseTimeMs() != null) {
-                        fraudDetectionService.analyzeClassification(username, request.getResponseTimeMs());
-                }
-
-                // 2. Process Classification
-                Image image = imageRepository.findById(request.getImageId())
-                                .orElseThrow(() -> new ResourceNotFoundException(
-                                                "Image not found: " + request.getImageId()));
-
-                Optional<GoldImage> goldImageOpt = goldImageRepository.findByImageId(image.getId());
-
-                TaskProvider.TaskInfo taskInfo = taskProvider.getTaskInfo(request.getTaskId());
-                String species = taskInfo.querySpecies();
-                if (goldImageOpt.isPresent() && species == null) {
-                        species = goldImageOpt.get().getSpecies();
-                }
-
-                if (goldImageOpt.isPresent()) {
-                        GoldImage goldImage = goldImageOpt.get();
-                        boolean isCorrect = goldImage.getCorrectAnswer().name()
-                                        .equals(request.getDecision().name());
-
-                        credibilityRepository.save(CredibilityRecord.builder()
-                                        .username(username)
-                                        .taskId(request.getTaskId())
-                                        .goldImage(goldImage)
-                                        .querySpecies(goldImage.getSpecies())
-                                        .userResponse(request.getDecision())
-                                        .correctAnswer(goldImage.getCorrectAnswer())
-                                        .build());
-
-                        ClassificationSubmittedEvent event = ClassificationSubmittedEvent.builder()
-                                        .username(username)
-                                        .classificationId(null)
-                                        .imageId(image.getId())
-                                        .taskId(request.getTaskId())
-                                        .isCorrect(isCorrect)
-                                        .isGoldStandard(true)
-                                        .submittedAt(java.time.LocalDateTime.now())
-                                        .species(species)
-                                        .responseTimeMs(request.getResponseTimeMs())
-                                        .userCredibility(userCredibility)
-                                        .build();
-
-                        eventPublisher.publishEvent(event);
-
-                } else {
-                        Classification classification = Classification.builder()
-                                        .username(username)
-                                        .userRole(userRole)
-                                        .taskId(request.getTaskId())
-                                        .image(image)
-                                        .querySpecies(species)
-                                        .userResponse(request.getDecision())
-                                        .build();
-
-                        Classification saved = classificationRepository.save(classification);
-
-                        ClassificationSubmittedEvent event = ClassificationSubmittedEvent.builder()
-                                        .username(username)
-                                        .classificationId(saved.getId())
-                                        .imageId(image.getId())
-                                        .taskId(request.getTaskId())
-                                        .isCorrect(false)
-                                        .isGoldStandard(false)
-                                        .submittedAt(saved.getCreatedAt())
-                                        .species(species)
-                                        .responseTimeMs(request.getResponseTimeMs())
-                                        .userCredibility(userCredibility)
-                                        .build();
-
-                        eventPublisher.publishEvent(event);
-                }
-
-                // 3. Return Next Batch
-                return imageService.getNextBatchForApi(request.getTaskId(), username, 10);
+        // 1. Fraud Detection
+        if (request.getResponseTimeMs() != null) {
+            fraudDetectionService.analyzeClassification(username, request.getResponseTimeMs());
         }
 
-        @Transactional
-        public void submitBatchResponses(String username, String userRole, Long taskId,
-                        List<UserClassification> responses) {
-                // Kept for backward compatibility
-                for (UserClassification response : responses) {
-                        Image image = imageRepository.findById(response.getImageId())
-                                        .orElseThrow(() -> new ResourceNotFoundException(
-                                                        "Image not found: " + response.getImageId()));
+        // 2. Load Image
+        Image image = imageRepository.findById(request.getImageId())
+                .orElseThrow(() -> new ResourceNotFoundException("Image not found: " + request.getImageId()));
 
-                        TaskProvider.TaskInfo taskInfo = taskProvider.getTaskInfo(taskId);
-                        String species = taskInfo.querySpecies();
+        // 3. Evaluate (Gold or Regular) and publish event
+        Optional<GoldImageEvaluationResult> goldResult = goldImageEvaluatorService.evaluate(
+                image, request.getTaskId(), username, request.getDecision());
 
-                        Optional<GoldImage> goldImageOpt = goldImageRepository.findByImageId(image.getId());
+        ClassificationSubmittedEvent event;
+        if (goldResult.isPresent()) {
+            GoldImageEvaluationResult result = goldResult.get();
+            event = ClassificationSubmittedEvent.builder()
+                    .username(username)
+                    .classificationId(null)
+                    .imageId(image.getId())
+                    .taskId(request.getTaskId())
+                    .isCorrect(result.isCorrect())
+                    .isGoldStandard(true)
+                    .submittedAt(LocalDateTime.now())
+                    .species(result.species())
+                    .responseTimeMs(request.getResponseTimeMs())
+                    .userCredibility(userCredibility)
+                    .build();
+        } else {
+            String species = taskProvider.getTaskInfo(request.getTaskId()).querySpecies();
+            Classification classification = Classification.builder()
+                    .username(username)
+                    .userRole(userRole)
+                    .taskId(request.getTaskId())
+                    .image(image)
+                    .querySpecies(species)
+                    .userResponse(request.getDecision())
+                    .build();
+            Classification saved = classificationRepository.save(classification);
 
-                        if (goldImageOpt.isPresent() && species == null) {
-                                species = goldImageOpt.get().getSpecies();
-                        }
-
-                        if (goldImageOpt.isPresent()) {
-                                GoldImage goldImage = goldImageOpt.get();
-                                boolean isCorrect = goldImage.getCorrectAnswer().name()
-                                                .equals(response.getUserResponse().name());
-
-                                credibilityRepository.save(CredibilityRecord.builder()
-                                                .username(username)
-                                                .taskId(taskId)
-                                                .goldImage(goldImage)
-                                                .querySpecies(goldImage.getSpecies())
-                                                .userResponse(response.getUserResponse())
-                                                .correctAnswer(goldImage.getCorrectAnswer())
-                                                .build());
-
-                                ClassificationSubmittedEvent event = ClassificationSubmittedEvent.builder()
-                                                .username(username)
-                                                .classificationId(null)
-                                                .imageId(image.getId())
-                                                .taskId(taskId)
-                                                .isCorrect(isCorrect)
-                                                .isGoldStandard(true)
-                                                .submittedAt(java.time.LocalDateTime.now())
-                                                .species(species)
-                                                .userCredibility(null) // Not available in batch yet
-                                                .build();
-
-                                eventPublisher.publishEvent(event);
-
-                        } else {
-                                Classification classification = Classification.builder()
-                                                .username(username)
-                                                .userRole(userRole)
-                                                .taskId(taskId)
-                                                .image(image)
-                                                .querySpecies(species)
-                                                .userResponse(response.getUserResponse())
-                                                .build();
-
-                                Classification saved = classificationRepository.save(classification);
-
-                                ClassificationSubmittedEvent event = ClassificationSubmittedEvent.builder()
-                                                .username(username)
-                                                .classificationId(saved.getId())
-                                                .imageId(image.getId())
-                                                .taskId(taskId)
-                                                .isCorrect(false)
-                                                .isGoldStandard(false)
-                                                .submittedAt(saved.getCreatedAt())
-                                                .species(species)
-                                                .userCredibility(null)
-                                                .build();
-
-                                eventPublisher.publishEvent(event);
-                        }
-                }
+            event = ClassificationSubmittedEvent.builder()
+                    .username(username)
+                    .classificationId(saved.getId())
+                    .imageId(image.getId())
+                    .taskId(request.getTaskId())
+                    .isCorrect(false)
+                    .isGoldStandard(false)
+                    .submittedAt(saved.getCreatedAt())
+                    .species(species)
+                    .responseTimeMs(request.getResponseTimeMs())
+                    .userCredibility(userCredibility)
+                    .build();
         }
+
+        // 4. Publish Event
+        eventPublisher.publishEvent(event);
+
+        // 5. Return Next Batch
+        return imageService.getNextBatchForApi(request.getTaskId(), username, 10);
+    }
+
+    @Transactional
+    public void submitBatchResponses(String username, String userRole, Long taskId,
+            List<UserClassification> responses) {
+        for (UserClassification response : responses) {
+            Image image = imageRepository.findById(response.getImageId())
+                    .orElseThrow(() -> new ResourceNotFoundException("Image not found: " + response.getImageId()));
+
+            Optional<GoldImageEvaluationResult> goldResult = goldImageEvaluatorService.evaluate(
+                    image, taskId, username, response.getUserResponse());
+
+            ClassificationSubmittedEvent event;
+            if (goldResult.isPresent()) {
+                GoldImageEvaluationResult result = goldResult.get();
+                event = ClassificationSubmittedEvent.builder()
+                        .username(username)
+                        .classificationId(null)
+                        .imageId(image.getId())
+                        .taskId(taskId)
+                        .isCorrect(result.isCorrect())
+                        .isGoldStandard(true)
+                        .submittedAt(LocalDateTime.now())
+                        .species(result.species())
+                        .userCredibility(null)
+                        .build();
+            } else {
+                String species = taskProvider.getTaskInfo(taskId).querySpecies();
+                Classification classification = Classification.builder()
+                        .username(username)
+                        .userRole(userRole)
+                        .taskId(taskId)
+                        .image(image)
+                        .querySpecies(species)
+                        .userResponse(response.getUserResponse())
+                        .build();
+                Classification saved = classificationRepository.save(classification);
+
+                event = ClassificationSubmittedEvent.builder()
+                        .username(username)
+                        .classificationId(saved.getId())
+                        .imageId(image.getId())
+                        .taskId(taskId)
+                        .isCorrect(false)
+                        .isGoldStandard(false)
+                        .submittedAt(saved.getCreatedAt())
+                        .species(species)
+                        .userCredibility(null)
+                        .build();
+            }
+
+            eventPublisher.publishEvent(event);
+        }
+    }
 }

--- a/backend/src/main/java/com/swipelab/classification/application/GoldImageEvaluationResult.java
+++ b/backend/src/main/java/com/swipelab/classification/application/GoldImageEvaluationResult.java
@@ -1,0 +1,10 @@
+package com.swipelab.classification.application;
+
+/**
+ * Result returned by GoldImageEvaluatorService after evaluating a user's response
+ * against a gold-standard image.
+ */
+public record GoldImageEvaluationResult(
+        boolean isCorrect,
+        String species
+) {}

--- a/backend/src/main/java/com/swipelab/classification/application/GoldImageEvaluatorService.java
+++ b/backend/src/main/java/com/swipelab/classification/application/GoldImageEvaluatorService.java
@@ -1,0 +1,60 @@
+package com.swipelab.classification.application;
+
+import com.swipelab.classification.domain.Classification;
+import com.swipelab.classification.domain.CredibilityRecord;
+import com.swipelab.classification.domain.GoldImage;
+import com.swipelab.classification.domain.Image;
+import com.swipelab.classification.infrastructure.CredibilityRepository;
+import com.swipelab.classification.infrastructure.GoldImageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+/**
+ * Responsible exclusively for evaluating a user response against a gold-standard image.
+ *
+ * Extracted from ClassificationService to follow the Single Responsibility Principle.
+ * If the image is not a gold image, returns empty.
+ * If it is, evaluates correctness, persists a CredibilityRecord, and returns the result.
+ */
+@Service
+@RequiredArgsConstructor
+public class GoldImageEvaluatorService {
+
+    private final GoldImageRepository goldImageRepository;
+    private final CredibilityRepository credibilityRepository;
+
+    /**
+     * Evaluates the user's decision against a gold image (if one exists for the given image).
+     *
+     * @return Optional.empty() if the image is not a gold standard image,
+     *         otherwise a GoldImageEvaluationResult with correctness and species.
+     */
+    public Optional<GoldImageEvaluationResult> evaluate(
+            Image image,
+            Long taskId,
+            String username,
+            Classification.UserResponse decision) {
+
+        Optional<GoldImage> goldImageOpt = goldImageRepository.findByImageId(image.getId());
+        if (goldImageOpt.isEmpty()) {
+            return Optional.empty();
+        }
+
+        GoldImage goldImage = goldImageOpt.get();
+        boolean isCorrect = goldImage.getCorrectAnswer().name().equals(decision.name());
+        String species = goldImage.getSpecies();
+
+        credibilityRepository.save(CredibilityRecord.builder()
+                .username(username)
+                .taskId(taskId)
+                .goldImage(goldImage)
+                .querySpecies(species)
+                .userResponse(decision)
+                .correctAnswer(goldImage.getCorrectAnswer())
+                .build());
+
+        return Optional.of(new GoldImageEvaluationResult(isCorrect, species));
+    }
+}

--- a/backend/src/test/java/com/swipelab/classification/application/ClassificationServiceTest.java
+++ b/backend/src/test/java/com/swipelab/classification/application/ClassificationServiceTest.java
@@ -2,7 +2,6 @@ package com.swipelab.classification.application;
 
 import com.swipelab.classification.domain.Classification;
 import com.swipelab.classification.domain.FraudDetectionService;
-import com.swipelab.classification.domain.GoldImage;
 import com.swipelab.classification.domain.Image;
 import com.swipelab.classification.domain.ImageService;
 import com.swipelab.classification.dto.UserClassification;
@@ -10,8 +9,6 @@ import com.swipelab.classification.dto.api.NextBatchResponse;
 import com.swipelab.classification.dto.api.SubmitClassificationRequest;
 import com.swipelab.classification.events.ClassificationSubmittedEvent;
 import com.swipelab.classification.infrastructure.ClassificationRepository;
-import com.swipelab.classification.infrastructure.CredibilityRepository;
-import com.swipelab.classification.infrastructure.GoldImageRepository;
 import com.swipelab.classification.infrastructure.ImageRepository;
 import com.swipelab.exception.ResourceNotFoundException;
 import com.swipelab.classification.application.port.out.TaskProvider;
@@ -46,10 +43,7 @@ class ClassificationServiceTest {
     private TaskProvider taskProvider;
 
     @Mock
-    private GoldImageRepository goldImageRepository;
-
-    @Mock
-    private CredibilityRepository credibilityRepository;
+    private GoldImageEvaluatorService goldImageEvaluatorService;
 
     @Mock
     private ApplicationEventPublisher eventPublisher;
@@ -92,20 +86,18 @@ class ClassificationServiceTest {
 
     @Test
     void submitClassification_ShouldSaveCredibility_WhenGoldImageExists() {
-        GoldImage goldImage = new GoldImage();
-        goldImage.setCorrectAnswer(GoldImage.UserResponse.YES);
-        goldImage.setSpecies("Lion");
+        GoldImageEvaluationResult goldResult = new GoldImageEvaluationResult(true, "Lion");
 
         when(imageRepository.findById(1L)).thenReturn(Optional.of(image));
-        when(goldImageRepository.findByImageId(1L)).thenReturn(Optional.of(goldImage));
+        when(goldImageEvaluatorService.evaluate(any(), any(), any(), any()))
+                .thenReturn(Optional.of(goldResult));
         when(imageService.getNextBatchForApi(anyLong(), anyString(), anyInt()))
                 .thenReturn(NextBatchResponse.builder().build());
-        when(taskProvider.getTaskInfo(1L)).thenReturn(taskInfo);
 
         classificationService.submitClassification("testuser", "USER", 0.8, request);
 
         verify(fraudDetectionService, times(1)).analyzeClassification("testuser", 1500L);
-        verify(credibilityRepository, times(1)).save(any());
+        verify(goldImageEvaluatorService, times(1)).evaluate(any(), any(), any(), any());
         verify(classificationRepository, never()).save(any());
 
         ArgumentCaptor<ClassificationSubmittedEvent> eventCaptor = ArgumentCaptor.forClass(ClassificationSubmittedEvent.class);
@@ -119,7 +111,7 @@ class ClassificationServiceTest {
     @Test
     void submitClassification_ShouldSaveClassification_WhenRegularImage() {
         when(imageRepository.findById(1L)).thenReturn(Optional.of(image));
-        when(goldImageRepository.findByImageId(1L)).thenReturn(Optional.empty());
+        when(goldImageEvaluatorService.evaluate(any(), any(), any(), any())).thenReturn(Optional.empty());
         when(imageService.getNextBatchForApi(anyLong(), anyString(), anyInt()))
                 .thenReturn(NextBatchResponse.builder().build());
         when(taskProvider.getTaskInfo(1L)).thenReturn(taskInfo);
@@ -131,7 +123,7 @@ class ClassificationServiceTest {
         classificationService.submitClassification("testuser", "USER", 0.8, request);
 
         verify(fraudDetectionService, times(1)).analyzeClassification("testuser", 1500L);
-        verify(credibilityRepository, never()).save(any());
+        verify(goldImageEvaluatorService, times(1)).evaluate(any(), any(), any(), any());
         verify(classificationRepository, times(1)).save(any());
 
         ArgumentCaptor<ClassificationSubmittedEvent> eventCaptor = ArgumentCaptor.forClass(ClassificationSubmittedEvent.class);
@@ -152,7 +144,7 @@ class ClassificationServiceTest {
         savedClassification.setId(10L);
 
         when(imageRepository.findById(1L)).thenReturn(Optional.of(image));
-        when(goldImageRepository.findByImageId(1L)).thenReturn(Optional.empty());
+        when(goldImageEvaluatorService.evaluate(any(), any(), any(), any())).thenReturn(Optional.empty());
         when(taskProvider.getTaskInfo(1L)).thenReturn(taskInfo);
         when(classificationRepository.save(any(Classification.class))).thenReturn(savedClassification);
 


### PR DESCRIPTION
Phase 3: Dismantling the God Class
Problem: ClassificationService.submitClassification was doing too much — fraud detection, gold image lookup, correctness evaluation, credibility record saving, event building, and returning the next batch all in one ~80-line method.

What was extracted:

GoldImageEvaluationResult — a simple record holding (isCorrect, species) — the only data ClassificationService needs to know back from the gold image path.
GoldImageEvaluatorService — owns the entire gold image path:
Checks if the image is a gold standard image
Evaluates correctness
Saves the CredibilityRecord
Returns Optional<GoldImageEvaluationResult> (empty if not a gold image)
Result: ClassificationService is now a clean orchestrator with a clear 5-step flow: Fraud → Load Image → Evaluate → Publish Event → Return Next Batch. CredibilityRepository is no longer a direct dependency of ClassificationService.