### PR TITLE
refactor: abstract gold-image scheduling into a configurable GoldImag…

### DIFF
--- a/backend/src/main/java/com/swipelab/classification/domain/FrequencyBasedGoldImagePolicy.java
+++ b/backend/src/main/java/com/swipelab/classification/domain/FrequencyBasedGoldImagePolicy.java
@@ -1,0 +1,29 @@
+package com.swipelab.classification.domain;
+
+import com.swipelab.classification.infrastructure.ClassificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * Implements GoldImagePolicy using a frequency-based rule:
+ * serve a gold-standard image once every {@value GOLD_IMAGE_FREQUENCY} classifications.
+ *
+ * This class owns the data access needed for the policy decision,
+ * keeping that concern out of TaskDistributionService.
+ */
+@Component
+@RequiredArgsConstructor
+public class FrequencyBasedGoldImagePolicy implements GoldImagePolicy {
+
+    // 1 gold image per N regular classifications
+    private static final int GOLD_IMAGE_FREQUENCY = 15;
+
+    private final ClassificationRepository classificationRepository;
+
+    @Override
+    public boolean shouldServeGoldImage(String username, Long taskId) {
+        Long count = classificationRepository.countByUsernameAndTaskId(username, taskId);
+        if (count == null || count == 0) return false;
+        return count % GOLD_IMAGE_FREQUENCY == 0;
+    }
+}

--- a/backend/src/main/java/com/swipelab/classification/domain/GoldImagePolicy.java
+++ b/backend/src/main/java/com/swipelab/classification/domain/GoldImagePolicy.java
@@ -1,0 +1,20 @@
+package com.swipelab.classification.domain;
+
+/**
+ * Policy interface that decides whether the next image served to a user
+ * should be a gold-standard (quality control) image.
+ *
+ * Separates the distribution policy from both the data access layer and
+ * the TaskDistributionService orchestration logic.
+ */
+public interface GoldImagePolicy {
+
+    /**
+     * Returns true if the next image served to this user for this task
+     * should be a gold-standard image.
+     *
+     * @param username the user being served
+     * @param taskId   the task context
+     */
+    boolean shouldServeGoldImage(String username, Long taskId);
+}

--- a/backend/src/main/java/com/swipelab/classification/domain/TaskDistributionService.java
+++ b/backend/src/main/java/com/swipelab/classification/domain/TaskDistributionService.java
@@ -2,7 +2,6 @@ package com.swipelab.classification.domain;
 
 import com.swipelab.classification.infrastructure.ClassificationRepository;
 import com.swipelab.classification.infrastructure.ImageRepository;
-import com.swipelab.tasks.domain.Task;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -18,9 +17,7 @@ public class TaskDistributionService {
 
     private final ImageRepository imageRepository;
     private final ClassificationRepository classificationRepository;
-
-    // Gold image insertion ratio: 1 gold image per 15 regular images
-    private static final int GOLD_IMAGE_FREQUENCY = 15;
+    private final GoldImagePolicy goldImagePolicy;
 
     /**
      * Holds the selected image and the species to query for that image.
@@ -34,13 +31,7 @@ public class TaskDistributionService {
      */
     @Transactional(readOnly = true)
     public Optional<ImageSpeciesPair> getNextImageForUser(String username, Long taskId, List<String> taskSpecies) {
-        // Get user's classification count for gold-image scheduling
-        Long count = classificationRepository.countByUsernameAndTaskId(username, taskId);
-        if (count == null) count = 0L;
-
-        boolean shouldBeGold = (count > 0) && (count % GOLD_IMAGE_FREQUENCY == 0);
-
-        if (shouldBeGold) {
+        if (goldImagePolicy.shouldServeGoldImage(username, taskId)) {
             Optional<ImageSpeciesPair> goldPair = getNextGoldImagePair(username, taskId, taskSpecies);
             if (goldPair.isPresent()) return goldPair;
         }
@@ -68,7 +59,6 @@ public class TaskDistributionService {
      */
     private Optional<ImageSpeciesPair> getNextRegularImagePair(String username, Long taskId, List<String> taskSpecies) {
         int speciesCount = taskSpecies == null || taskSpecies.isEmpty() ? 1 : taskSpecies.size();
-        // Fetch a larger pool so we can find one with an un-queried species
         List<Image> candidates = imageRepository.findRegularImageCandidatesForUser(
                 username, taskId, speciesCount, PageRequest.of(0, 20));
 

--- a/backend/src/test/java/com/swipelab/classification/domain/TaskDistributionServiceTest.java
+++ b/backend/src/test/java/com/swipelab/classification/domain/TaskDistributionServiceTest.java
@@ -27,6 +27,9 @@ class TaskDistributionServiceTest {
     @Mock
     private ClassificationRepository classificationRepository;
 
+    @Mock
+    private GoldImagePolicy goldImagePolicy;
+
     @InjectMocks
     private TaskDistributionService taskDistributionService;
 
@@ -52,7 +55,7 @@ class TaskDistributionServiceTest {
 
     @Test
     void getNextImageForUser_ShouldReturnRegularImage() {
-        when(classificationRepository.countByUsernameAndTaskId("testuser", 1L)).thenReturn(0L);
+        when(goldImagePolicy.shouldServeGoldImage("testuser", 1L)).thenReturn(false);
         when(imageRepository.findRegularImageCandidatesForUser(eq("testuser"), eq(1L), eq(1), any(PageRequest.class)))
                 .thenReturn(List.of(regularImage2));
         when(classificationRepository.findQueriedSpeciesByUsernameAndImageId("testuser", 2L))
@@ -67,8 +70,8 @@ class TaskDistributionServiceTest {
     }
 
     @Test
-    void getNextImageForUser_ShouldReturnGoldImage_WhenCountIs15() {
-        when(classificationRepository.countByUsernameAndTaskId("testuser", 1L)).thenReturn(15L);
+    void getNextImageForUser_ShouldReturnGoldImage_WhenPolicySaysGold() {
+        when(goldImagePolicy.shouldServeGoldImage("testuser", 1L)).thenReturn(true);
         when(imageRepository.findUnclassifiedGoldImages("testuser", 1L))
                 .thenReturn(List.of(goldImage));
         when(classificationRepository.findQueriedSpeciesByUsernameAndImageId("testuser", 3L))
@@ -84,7 +87,7 @@ class TaskDistributionServiceTest {
 
     @Test
     void getNextImageForUser_ShouldFallbackToRegularImage_WhenNoGoldAvailable() {
-        when(classificationRepository.countByUsernameAndTaskId("testuser", 1L)).thenReturn(15L);
+        when(goldImagePolicy.shouldServeGoldImage("testuser", 1L)).thenReturn(true);
         when(imageRepository.findUnclassifiedGoldImages("testuser", 1L))
                 .thenReturn(Collections.emptyList());
         when(imageRepository.findRegularImageCandidatesForUser(eq("testuser"), eq(1L), eq(1), any(PageRequest.class)))


### PR DESCRIPTION
Phase 4: Abstracting Distribution Policies
Problem: TaskDistributionService was directly calling ClassificationRepository.countByUsernameAndTaskId() to make a policy decision ("should I serve a gold image?"). This mixed data access with business rules inside an orchestration service.

What was created:

GoldImagePolicy (interface) — a single-method contract: shouldServeGoldImage(username, taskId)
FrequencyBasedGoldImagePolicy (implementation) — owns the ClassificationRepository dependency and the GOLD_IMAGE_FREQUENCY = 15 constant. Fully isolated and independently testable.
TaskDistributionService changes:

Removed classificationRepository.countByUsernameAndTaskId() call from the orchestration method
Now simply asks goldImagePolicy.shouldServeGoldImage(...) — doesn't care how the decision is made
The GOLD_IMAGE_FREQUENCY constant moved to where it belongs: inside the policy
Tests:

TaskDistributionServiceTest now mocks GoldImagePolicy — tests are cleaner and express intent directly: "when policy says gold → expect gold image" instead of "when count is 15 → expect gold image"