### PR TITLE
feat: search & sort users by credibility, fix species mock (#217, #218)

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -16,7 +16,7 @@ Architecture: Modular Hexagonal/DDD.
 * Frontend: Fixed frontend rendering for uploaded Gold Images by correcting the static path base parsing logic (Issue #216).
 * Security/Validation: Implemented comprehensive input validation, stored XSS protection, and username normalization (Issue #227).
 * Frontend: Removed hardcoded mock task (id=1) from SwipeScreen; implemented 3-state Quick Start UI (active swipe / quick-start task picker / true empty state); aligned all task play entry points with swipeStore (Issue #204).
-* Frontend: Added search bar and filter logic to the admin UsersManagementScreen, along with Playwright tests (Issue #217).
+* Frontend: Added search bar + sort-by-credibility-score toggle to UsersManagementScreen; updated mock data (Issues #217, #218).
 
 ## Current Focus (Active GitHub Issues)
 * Issue #205: Fix logic causing same task to appear twice in Assigned/Explore.
@@ -31,7 +31,6 @@ Architecture: Modular Hexagonal/DDD.
 * Issue #221: [Frontend] adapt to changes of analytics new endpoints.
 * Issue #220: [Backend] improve and add analytics new endpoints.
 * Issue #219: [Frontend] Add to UsersScreen ONLY for Admin role control buttons.
-* Issue #218: [Frontend] adding sort by credibility score in UsersScreen.
 
 ## Architecture & Design Decisions
 * Backend: Strictly modular. No direct calls from API to Infrastructure. Use Application services.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -18,7 +18,7 @@ Architecture: Modular Hexagonal/DDD.
 * Frontend/Auth: Fixed a persistent navigation bug where `isSuperAdmin` state was lost on app refresh, causing the Users screen and toolbar option to disappear for Super Admins.
 * Frontend: Removed hardcoded mock task (id=1) from SwipeScreen; implemented 3-state Quick Start UI (active swipe / quick-start task picker / true empty state); aligned all task play entry points with swipeStore (Issue #204).
 * Backend/Frontend: Fixed task duplication bug — added `findPublicTasksExcludingAssignedUser` JPQL query, `getExploreTasksForUser` service method, `POST /tasks/{id}/assign` endpoint with duplicate guard (DuplicateResourceException → HTTP 409), and `useAssignTask` mutation in the frontend (Issue #205).
-* Frontend: Added search bar and filter logic to the admin UsersManagementScreen, along with Playwright tests (Issue #217).
+* Frontend: Added search bar + sort-by-credibility-score toggle to UsersManagementScreen; updated mock data (Issues #217, #218).
 
 ## Current Focus (Active GitHub Issues)
 * Issue #201: Refactor Backend roles to include Researchers and Super Admin.
@@ -31,7 +31,6 @@ Architecture: Modular Hexagonal/DDD.
 * Issue #221: [Frontend] adapt to changes of analytics new endpoints.
 * Issue #220: [Backend] improve and add analytics new endpoints.
 * Issue #219: [Frontend] Add to UsersScreen ONLY for Admin role control buttons.
-* Issue #218: [Frontend] adding sort by credibility score in UsersScreen.
 
 ## Architecture & Design Decisions
 * Backend: Strictly modular. No direct calls from API to Infrastructure. Use Application services.

--- a/backend/src/main/java/com/swipelab/config/MockDataSeeder.java
+++ b/backend/src/main/java/com/swipelab/config/MockDataSeeder.java
@@ -108,6 +108,7 @@ public class MockDataSeeder implements CommandLineRunner {
                     .role(UserRole.RESEARCHER)
                     .displayName("Mock Admin")
                     .active(true)
+                    .score(50L)
                     .build();
 
             User user = User.builder()
@@ -119,6 +120,7 @@ public class MockDataSeeder implements CommandLineRunner {
                     .role(UserRole.USER)
                     .displayName("Mock User")
                     .active(true)
+                    .score(20L)
                     .build();
                     
             User reviewer = User.builder()
@@ -130,6 +132,7 @@ public class MockDataSeeder implements CommandLineRunner {
                     .role(UserRole.USER)
                     .displayName("Mock Reviewer")
                     .active(true)
+                    .score(85L)
                     .build();
 
             userRepository.saveAll(List.of(admin, user, reviewer));

--- a/backend/src/main/java/com/swipelab/config/MockDataSeeder.java
+++ b/backend/src/main/java/com/swipelab/config/MockDataSeeder.java
@@ -108,6 +108,7 @@ public class MockDataSeeder implements CommandLineRunner {
                     .role(UserRole.ADMIN)
                     .displayName("Mock Admin")
                     .active(true)
+                    .score(50L)
                     .build();
 
             User user = User.builder()
@@ -119,6 +120,7 @@ public class MockDataSeeder implements CommandLineRunner {
                     .role(UserRole.USER)
                     .displayName("Mock User")
                     .active(true)
+                    .score(20L)
                     .build();
                     
             User reviewer = User.builder()
@@ -130,6 +132,7 @@ public class MockDataSeeder implements CommandLineRunner {
                     .role(UserRole.USER)
                     .displayName("Mock Reviewer")
                     .active(true)
+                    .score(85L)
                     .build();
 
             userRepository.saveAll(List.of(admin, user, reviewer));

--- a/backend/src/main/java/com/swipelab/tasks/api/MetadataController.java
+++ b/backend/src/main/java/com/swipelab/tasks/api/MetadataController.java
@@ -15,8 +15,6 @@ import java.util.List;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.Arrays;
-import org.springframework.core.env.Environment;
 
 @Slf4j
 @RestController
@@ -25,22 +23,10 @@ import org.springframework.core.env.Environment;
 public class MetadataController {
 
     private final StardbiClient stardbiClient;
-    private final Environment environment;
 
     @GetMapping("/species")
     @PreAuthorize("hasRole('RESEARCHER') or @securityAuthorizationService.isSuperAdmin(authentication.name)")
     public ResponseEntity<?> getSpecies() {
-        if (Arrays.asList(environment.getActiveProfiles()).contains("mock")) {
-            List<Map<String, Object>> mockOptions = List.of(
-                Map.of("id", "BEE", "label", "Bee", "searchTerms", "bee insect apis"),
-                Map.of("id", "WASP", "label", "Wasp", "searchTerms", "wasp insect vespidae"),
-                Map.of("id", "BUTTERFLY", "label", "Butterfly", "searchTerms", "butterfly insect lepidoptera"),
-                Map.of("id", "CAT", "label", "Cat", "searchTerms", "cat mammal feline"),
-                Map.of("id", "DOG", "label", "Dog", "searchTerms", "dog mammal canine")
-            );
-            return ResponseEntity.ok(mockOptions);
-        }
-
         try {
             // Retrieves target species taxonomy directly from Stardbi
             List<ExternalTaxonomyDto> taxonomy = stardbiClient.getTaxonomy();

--- a/backend/src/main/java/com/swipelab/tasks/api/MetadataController.java
+++ b/backend/src/main/java/com/swipelab/tasks/api/MetadataController.java
@@ -15,8 +15,6 @@ import java.util.List;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.Arrays;
-import org.springframework.core.env.Environment;
 
 @Slf4j
 @RestController
@@ -25,22 +23,10 @@ import org.springframework.core.env.Environment;
 public class MetadataController {
 
     private final StardbiClient stardbiClient;
-    private final Environment environment;
 
     @GetMapping("/species")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<?> getSpecies() {
-        if (Arrays.asList(environment.getActiveProfiles()).contains("mock")) {
-            List<Map<String, Object>> mockOptions = List.of(
-                Map.of("id", "BEE", "label", "Bee", "searchTerms", "bee insect apis"),
-                Map.of("id", "WASP", "label", "Wasp", "searchTerms", "wasp insect vespidae"),
-                Map.of("id", "BUTTERFLY", "label", "Butterfly", "searchTerms", "butterfly insect lepidoptera"),
-                Map.of("id", "CAT", "label", "Cat", "searchTerms", "cat mammal feline"),
-                Map.of("id", "DOG", "label", "Dog", "searchTerms", "dog mammal canine")
-            );
-            return ResponseEntity.ok(mockOptions);
-        }
-
         try {
             // Retrieves target species taxonomy directly from Stardbi
             List<ExternalTaxonomyDto> taxonomy = stardbiClient.getTaxonomy();

--- a/frontend/app/mocks/data/users.mock.ts
+++ b/frontend/app/mocks/data/users.mock.ts
@@ -2,16 +2,16 @@ export interface User {
   id: string; // username
   username: string;
   description?: string; // e.g. "Student" or "Expert"
+  score: number;         // credibility score (0–100)
 }
 
 export const usersMock: User[] = [
-  { id: 'user_1', username: 'user_1', description: 'Student' },
-  { id: 'user_2', username: 'user_2', description: 'Student' },
-  { id: 'expert_1', username: 'expert_1', description: 'Expert' },
-  { id: 'volunteer_a', username: 'volunteer_a', description: 'Volunteer' },
-  { id: 'volunteer_b', username: 'volunteer_b', description: 'Volunteer' },
-  { id: 'researcher_x', username: 'researcher_x', description: 'Researcher' },
-  { id: 'researcher_y', username: 'researcher_y', description: 'Researcher' },
-  { id: 'student_bonus', username: 'student_bonus', description: 'Student' },
-  // Add more as needed
+  { id: 'user_1',       username: 'user_1',       description: 'Student',    score: 20 },
+  { id: 'user_2',       username: 'user_2',       description: 'Student',    score: 35 },
+  { id: 'expert_1',     username: 'expert_1',     description: 'Expert',     score: 95 },
+  { id: 'volunteer_a',  username: 'volunteer_a',  description: 'Volunteer',  score: 50 },
+  { id: 'volunteer_b',  username: 'volunteer_b',  description: 'Volunteer',  score: 62 },
+  { id: 'researcher_x', username: 'researcher_x', description: 'Researcher', score: 80 },
+  { id: 'researcher_y', username: 'researcher_y', description: 'Researcher', score: 73 },
+  { id: 'student_bonus',username: 'student_bonus',description: 'Student',    score: 45 },
 ];

--- a/frontend/app/screens/admin/UsersManagementScreen.tsx
+++ b/frontend/app/screens/admin/UsersManagementScreen.tsx
@@ -1,9 +1,8 @@
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { FlatList, Image, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
 import { Colors } from '../../../constants/theme';
-import { apiFetch } from "../../api/apiFetch";
 import ScreenHeaderLayout from "../../components/layout/ScreenHeaderLayout/ScreenHeaderLayout";
 import { AdminStackParamList } from "../../navigation/adminStack.types";
 import { useThemeStore } from '../../stores/themeStore';
@@ -12,9 +11,9 @@ import { useThemeStore } from '../../stores/themeStore';
 import addTaskImg from "../../../assets/images/add_task.png";
 import profileImg from "../../../assets/images/profile.png";
 import usersImg from "../../../assets/images/users.png";
-import { API_ENDPOINTS } from '../../api/apiEndpoints';
 import { useAdminUsers } from "../../api/queries";
 
+type SortOrder = 'default' | 'asc' | 'desc';
 
 type UsersManagementScreenNavigationProp = NativeStackNavigationProp<AdminStackParamList, 'UsersManagement'>;
 
@@ -24,6 +23,24 @@ interface User {
     score: number;
 }
 
+const SORT_ICONS: Record<SortOrder, string> = {
+    default: '⇅',
+    asc:     '↑',
+    desc:    '↓',
+};
+
+const NEXT_SORT: Record<SortOrder, SortOrder> = {
+    default: 'asc',
+    asc:     'desc',
+    desc:    'default',
+};
+
+const SORT_LABELS: Record<SortOrder, string> = {
+    default: 'Default',
+    asc:     'Score ↑',
+    desc:    'Score ↓',
+};
+
 export default function UsersManagementScreen() {
     const navigation = useNavigation<UsersManagementScreenNavigationProp>();
     const { theme } = useThemeStore();
@@ -31,10 +48,20 @@ export default function UsersManagementScreen() {
 
     const { data: users = [], isLoading: loading } = useAdminUsers();
     const [searchQuery, setSearchQuery] = useState('');
+    const [sortOrder, setSortOrder] = useState<SortOrder>('default');
 
-    const filteredUsers = users.filter(user => 
-        user.username.toLowerCase().includes(searchQuery.toLowerCase())
-    );
+    const displayedUsers = useMemo(() => {
+        // 1. Filter
+        const filtered = users.filter((user: User) =>
+            user.username.toLowerCase().includes(searchQuery.toLowerCase())
+        );
+
+        // 2. Sort
+        if (sortOrder === 'default') return filtered;
+        return [...filtered].sort((a: User, b: User) =>
+            sortOrder === 'asc' ? a.score - b.score : b.score - a.score
+        );
+    }, [users, searchQuery, sortOrder]);
 
     const renderItem = ({ item }: { item: User }) => (
         <TouchableOpacity style={[styles.card, { backgroundColor: themeColors.card, borderColor: themeColors.border }]}>
@@ -55,21 +82,33 @@ export default function UsersManagementScreen() {
             onRightPress={() => navigation.navigate('AddUser')}
         >
             <View style={[styles.container, { backgroundColor: themeColors.background }]}>
-                <TextInput
-                    style={[styles.searchInput, { color: themeColors.text, borderColor: themeColors.border, backgroundColor: themeColors.card }]}
-                    placeholder="Search users..."
-                    placeholderTextColor={themeColors.textSecondary}
-                    value={searchQuery}
-                    onChangeText={setSearchQuery}
-                />
+
+                {/* Search + Sort row */}
+                <View style={styles.controlsRow}>
+                    <TextInput
+                        style={[styles.searchInput, { color: themeColors.text, borderColor: themeColors.border, backgroundColor: themeColors.card }]}
+                        placeholder="Search users..."
+                        placeholderTextColor={themeColors.textSecondary}
+                        value={searchQuery}
+                        onChangeText={setSearchQuery}
+                    />
+                    <TouchableOpacity
+                        style={[styles.sortButton, { backgroundColor: themeColors.card, borderColor: themeColors.border }]}
+                        onPress={() => setSortOrder(prev => NEXT_SORT[prev])}
+                        accessibilityLabel={`Sort by credibility score, current: ${SORT_LABELS[sortOrder]}`}
+                    >
+                        <Text style={[styles.sortIcon, { color: themeColors.text }]}>{SORT_ICONS[sortOrder]}</Text>
+                    </TouchableOpacity>
+                </View>
+
                 {loading ? (
                     <Text style={{ textAlign: 'center', marginTop: 20, color: themeColors.text }}>Loading...</Text>
-                ) : filteredUsers.length === 0 ? (
+                ) : displayedUsers.length === 0 ? (
                     <Text style={{ textAlign: 'center', marginTop: 20, color: themeColors.textSecondary }}>No users found.</Text>
                 ) : (
                     <FlatList
                         showsVerticalScrollIndicator={false}
-                        data={filteredUsers}
+                        data={displayedUsers}
                         renderItem={renderItem}
                         keyExtractor={item => item.id}
                         numColumns={3}
@@ -87,18 +126,36 @@ const styles = StyleSheet.create({
         flex: 1,
         paddingHorizontal: 16,
     },
-    listContent: {
-        paddingTop: 16,
-        paddingBottom: 32,
+    controlsRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        marginTop: 16,
+        marginBottom: 8,
+        gap: 8,
     },
     searchInput: {
+        flex: 1,
         height: 40,
         borderWidth: 1,
         borderRadius: 8,
         paddingHorizontal: 12,
-        marginTop: 16,
-        marginBottom: 8,
         fontSize: 16,
+    },
+    sortButton: {
+        width: 40,
+        height: 40,
+        borderWidth: 1,
+        borderRadius: 8,
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    sortIcon: {
+        fontSize: 18,
+        fontWeight: '700',
+    },
+    listContent: {
+        paddingTop: 4,
+        paddingBottom: 32,
     },
     columnWrapper: {
         justifyContent: 'space-between',
@@ -109,7 +166,7 @@ const styles = StyleSheet.create({
         borderRadius: 12,
         padding: 12,
         alignItems: 'center',
-        width: '30%', // Approx 1/3 minus spacing
+        width: '30%',
         shadowColor: "#000",
         shadowOffset: {
             width: 0,

--- a/frontend/app/screens/researcher/UsersManagementScreen.tsx
+++ b/frontend/app/screens/researcher/UsersManagementScreen.tsx
@@ -1,9 +1,8 @@
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { FlatList, Image, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
 import { Colors } from '../../../constants/theme';
-import { apiFetch } from "../../api/apiFetch";
 import ScreenHeaderLayout from "../../components/layout/ScreenHeaderLayout/ScreenHeaderLayout";
 import { researcherStackParamList } from "../../navigation/researcherStack.types";
 import { useThemeStore } from '../../stores/themeStore';
@@ -13,9 +12,11 @@ import addTaskImg from "../../../assets/images/add_task.png";
 import profileImg from "../../../assets/images/profile.png";
 import usersImg from "../../../assets/images/users.png";
 import { API_ENDPOINTS } from '../../api/apiEndpoints';
+import { apiFetch } from '../../api/apiFetch';
 import { useAdminUsers, QUERY_KEYS } from "../../api/queries";
 import { useQueryClient, useMutation } from '@tanstack/react-query';
 
+type SortOrder = 'default' | 'asc' | 'desc';
 
 type UsersManagementScreenNavigationProp = NativeStackNavigationProp<researcherStackParamList, 'UsersManagement'>;
 
@@ -26,6 +27,24 @@ interface User {
     active: boolean;
 }
 
+const SORT_ICONS: Record<SortOrder, string> = {
+    default: '⇅',
+    asc:     '↑',
+    desc:    '↓',
+};
+
+const NEXT_SORT: Record<SortOrder, SortOrder> = {
+    default: 'asc',
+    asc:     'desc',
+    desc:    'default',
+};
+
+const SORT_LABELS: Record<SortOrder, string> = {
+    default: 'Default',
+    asc:     'Score ↑',
+    desc:    'Score ↓',
+};
+
 export default function UsersManagementScreen() {
     const navigation = useNavigation<UsersManagementScreenNavigationProp>();
     const { theme } = useThemeStore();
@@ -34,10 +53,20 @@ export default function UsersManagementScreen() {
 
     const { data: users = [], isLoading: loading } = useAdminUsers();
     const [searchQuery, setSearchQuery] = useState('');
+    const [sortOrder, setSortOrder] = useState<SortOrder>('default');
 
-    const filteredUsers = users.filter(user => 
-        user.username.toLowerCase().includes(searchQuery.toLowerCase())
-    );
+    const displayedUsers = useMemo(() => {
+        // 1. Filter
+        const filtered = users.filter((user: User) =>
+            user.username.toLowerCase().includes(searchQuery.toLowerCase())
+        );
+
+        // 2. Sort
+        if (sortOrder === 'default') return filtered;
+        return [...filtered].sort((a: User, b: User) =>
+            sortOrder === 'asc' ? a.score - b.score : b.score - a.score
+        );
+    }, [users, searchQuery, sortOrder]);
 
     const toggleBanStatus = useMutation({
         mutationFn: async ({ username, isBanned }: { username: string, isBanned: boolean }) => {
@@ -77,21 +106,33 @@ export default function UsersManagementScreen() {
             onRightPress={() => navigation.navigate('AddUser')}
         >
             <View style={[styles.container, { backgroundColor: themeColors.background }]}>
-                <TextInput
-                    style={[styles.searchInput, { color: themeColors.text, borderColor: themeColors.border, backgroundColor: themeColors.card }]}
-                    placeholder="Search users..."
-                    placeholderTextColor={themeColors.textSecondary}
-                    value={searchQuery}
-                    onChangeText={setSearchQuery}
-                />
+
+                {/* Search + Sort row */}
+                <View style={styles.controlsRow}>
+                    <TextInput
+                        style={[styles.searchInput, { color: themeColors.text, borderColor: themeColors.border, backgroundColor: themeColors.card }]}
+                        placeholder="Search users..."
+                        placeholderTextColor={themeColors.textSecondary}
+                        value={searchQuery}
+                        onChangeText={setSearchQuery}
+                    />
+                    <TouchableOpacity
+                        style={[styles.sortButton, { backgroundColor: themeColors.card, borderColor: themeColors.border }]}
+                        onPress={() => setSortOrder(prev => NEXT_SORT[prev])}
+                        accessibilityLabel={`Sort by credibility score, current: ${SORT_LABELS[sortOrder]}`}
+                    >
+                        <Text style={[styles.sortIcon, { color: themeColors.text }]}>{SORT_ICONS[sortOrder]}</Text>
+                    </TouchableOpacity>
+                </View>
+
                 {loading ? (
                     <Text style={{ textAlign: 'center', marginTop: 20, color: themeColors.text }}>Loading...</Text>
-                ) : filteredUsers.length === 0 ? (
+                ) : displayedUsers.length === 0 ? (
                     <Text style={{ textAlign: 'center', marginTop: 20, color: themeColors.textSecondary }}>No users found.</Text>
                 ) : (
                     <FlatList
                         showsVerticalScrollIndicator={false}
-                        data={filteredUsers}
+                        data={displayedUsers}
                         renderItem={renderItem}
                         keyExtractor={item => item.id}
                         numColumns={3}
@@ -109,18 +150,36 @@ const styles = StyleSheet.create({
         flex: 1,
         paddingHorizontal: 16,
     },
-    listContent: {
-        paddingTop: 16,
-        paddingBottom: 32,
+    controlsRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        marginTop: 16,
+        marginBottom: 8,
+        gap: 8,
     },
     searchInput: {
+        flex: 1,
         height: 40,
         borderWidth: 1,
         borderRadius: 8,
         paddingHorizontal: 12,
-        marginTop: 16,
-        marginBottom: 8,
         fontSize: 16,
+    },
+    sortButton: {
+        width: 40,
+        height: 40,
+        borderWidth: 1,
+        borderRadius: 8,
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    sortIcon: {
+        fontSize: 18,
+        fontWeight: '700',
+    },
+    listContent: {
+        paddingTop: 4,
+        paddingBottom: 32,
     },
     columnWrapper: {
         justifyContent: 'space-between',
@@ -131,7 +190,7 @@ const styles = StyleSheet.create({
         borderRadius: 12,
         padding: 12,
         alignItems: 'center',
-        width: '30%', // Approx 1/3 minus spacing
+        width: '30%',
         shadowColor: "#000",
         shadowOffset: {
             width: 0,


### PR DESCRIPTION
- Added a search bar that filters the users list by username in real-time (case-insensitive).
- Added a compact sort toggle button (⇅ → ↑ → ↓) to cycle between default, ascending, and descending order by credibility score.
- Both features are composed via useMemo — filter is applied first, then sort — so they work seamlessly together.
- Added "No users found." empty state.