### PR TITLE
Frontend/bugfix/recipients list fix

### DIFF
--- a/backend/src/main/java/com/swipelab/recipients/application/RecipientGroupService.java
+++ b/backend/src/main/java/com/swipelab/recipients/application/RecipientGroupService.java
@@ -22,6 +22,26 @@ public class RecipientGroupService {
     private final RecipientGroupRepository recipientGroupRepository;
     private final com.swipelab.recipients.infrastructure.RecipientUserRepository recipientUserRepository;
 
+    private Set<RecipientUser> getOrCreateRecipientUsers(List<String> usernames) {
+        if (usernames == null || usernames.isEmpty()) {
+            return new java.util.HashSet<>();
+        }
+        Set<RecipientUser> existingUsers = recipientUserRepository.findByUsernameIn(usernames);
+        Set<String> existingUsernames = existingUsers.stream()
+                .map(RecipientUser::getUsername)
+                .collect(java.util.stream.Collectors.toSet());
+
+        List<RecipientUser> newUsers = usernames.stream()
+                .filter(u -> !existingUsernames.contains(u))
+                .map(u -> RecipientUser.builder().username(u).active(true).build())
+                .toList();
+
+        if (!newUsers.isEmpty()) {
+            existingUsers.addAll(recipientUserRepository.saveAll(newUsers));
+        }
+        return existingUsers;
+    }
+
     @Transactional
     public RecipientGroupResponse createRecipientGroup(CreateRecipientGroupRequest request, String username) {
         if (recipientGroupRepository.existsByCreatedByAndName(username, request.getName())) {
@@ -29,7 +49,7 @@ public class RecipientGroupService {
                     "Recipient group with name '" + request.getName() + "' already exists for your account");
         }
 
-        Set<RecipientUser> users = recipientUserRepository.findByUsernameIn(request.getUsernames());
+        Set<RecipientUser> users = getOrCreateRecipientUsers(request.getUsernames());
 
         RecipientGroup group = RecipientGroup.builder()
                 .name(request.getName())
@@ -47,7 +67,7 @@ public class RecipientGroupService {
                 .orElseThrow(() -> new ResourceNotFoundException("RecipientGroup id:" + groupId + " not found"));
 
         if (request.getAddUsernames() != null && !request.getAddUsernames().isEmpty()) {
-            Set<RecipientUser> usersToAdd = recipientUserRepository.findByUsernameIn(request.getAddUsernames());
+            Set<RecipientUser> usersToAdd = getOrCreateRecipientUsers(request.getAddUsernames());
             group.addUsers(usersToAdd);
         }
 

--- a/backend/src/main/java/com/swipelab/recipients/domain/RecipientGroup.java
+++ b/backend/src/main/java/com/swipelab/recipients/domain/RecipientGroup.java
@@ -78,7 +78,7 @@ public class RecipientGroup {
     }
 
     public void removeUser(RecipientUser user) {
-        users.remove(user);
+        users.removeIf(u -> u.getUsername().equals(user.getUsername()));
     }
 
     public void addUsers(Set<RecipientUser> usersToAdd) {
@@ -86,6 +86,9 @@ public class RecipientGroup {
     }
 
     public void removeUsers(Set<RecipientUser> usersToRemove) {
-        users.removeAll(usersToRemove);
+        Set<String> usernamesToRemove = usersToRemove.stream()
+                .map(RecipientUser::getUsername)
+                .collect(java.util.stream.Collectors.toSet());
+        users.removeIf(u -> usernamesToRemove.contains(u.getUsername()));
     }
 }

--- a/backend/src/main/java/com/swipelab/recipients/domain/RecipientUser.java
+++ b/backend/src/main/java/com/swipelab/recipients/domain/RecipientUser.java
@@ -14,9 +14,11 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@lombok.EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class RecipientUser {
 
     @Id
+    @lombok.EqualsAndHashCode.Include
     private String username;
 
     @Builder.Default

--- a/frontend/app/api/apiEndpoints.ts
+++ b/frontend/app/api/apiEndpoints.ts
@@ -63,7 +63,7 @@ export const API_ENDPOINTS = {
         //RECIPIENTS
         RECIPIENTS: '/api/v1/dashboard/recipients',
         RECIPIENTS_CREATE: '/api/v1/dashboard/recipients',
-        RECIPIENTS_UPDATE: (groupId: string | number) => `/api/v1/dashboard/recipients/${groupId}/update`,
+        RECIPIENTS_UPDATE: (groupId: string | number) => `/api/v1/dashboard/recipients/${groupId}`,
     },
     STARDBI: {
         LOGIN: 'https://stardbi.cs.bgu.ac.il/auth/get_token/',

--- a/frontend/app/screens/researcher/RecipientGroupDetailsScreen.tsx
+++ b/frontend/app/screens/researcher/RecipientGroupDetailsScreen.tsx
@@ -46,6 +46,7 @@ export default function RecipientGroupDetailsScreen() {
 
     // Add Member Modal State
     const [addMemberModalVisible, setAddMemberModalVisible] = useState(false);
+    const [userToRemove, setUserToRemove] = useState<string | null>(null);
     const [activeTab, setActiveTab] = useState<'USERS' | 'GROUPS'>('USERS');
 
     // Selection State
@@ -132,55 +133,34 @@ export default function RecipientGroupDetailsScreen() {
         }
     };
 
-    const handleRemoveUser = async (userId: string) => {
-        console.log("[handleRemoveUser] Triggered for user:", userId);
-        
-        const removeUserAction = async () => {
-            console.log("[handleRemoveUser] User confirmed removal. Proceeding with apiFetch...");
-            try {
-                const url = API_ENDPOINTS.researcher.RECIPIENTS_UPDATE(currentGroup.id);
-                console.log("[handleRemoveUser] URL:", url);
-                
-                const res = await apiFetch(url, {
-                    method: 'PUT',
-                    headers: {
-                        'Content-Type': 'application/json'
-                    },
-                    body: JSON.stringify({ removeUsernames: [userId] })
-                });
-                
-                console.log("[handleRemoveUser] apiFetch response status:", res.status);
-                
-                if (res.ok) {
-                    console.log("[handleRemoveUser] Successfully removed, refreshing group...");
-                    refreshGroup();
-                } else {
-                    console.error("[handleRemoveUser] Failed to remove user. Status:", res.status);
-                    Alert.alert("Error", "Failed to remove user");
-                }
-            } catch (e) {
-                console.error("[handleRemoveUser] Exception during fetch:", e);
-                Alert.alert("Error", "Network error occurred while removing user.");
-            }
-        };
+    const handleRemoveUser = (userId: string) => {
+        setUserToRemove(userId);
+    };
 
-        if (Platform.OS === 'web') {
-            console.log("[handleRemoveUser] Running on web, using window.confirm");
-            if (window.confirm("Are you sure you want to remove this user from the group?")) {
-                removeUserAction();
+    const confirmRemoveUser = async () => {
+        if (!userToRemove) return;
+        const userId = userToRemove;
+        
+        try {
+            const url = API_ENDPOINTS.researcher.RECIPIENTS_UPDATE(currentGroup.id);
+            const res = await apiFetch(url, {
+                method: 'PUT',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ removeUsernames: [userId] })
+            });
+            
+            if (res.ok) {
+                refreshGroup();
             } else {
-                console.log("[handleRemoveUser] User cancelled window.confirm");
+                Alert.alert("Error", "Failed to remove user");
             }
-        } else {
-            console.log("[handleRemoveUser] Running on native, using Alert.alert");
-            Alert.alert(
-                "Remove User",
-                "Are you sure you want to remove this user from the group?",
-                [
-                    { text: "Cancel", style: "cancel", onPress: () => console.log("[handleRemoveUser] Cancelled") },
-                    { text: "OK", onPress: removeUserAction }
-                ]
-            );
+        } catch (e) {
+            console.error("[confirmRemoveUser] Exception during fetch:", e);
+            Alert.alert("Error", "Network error occurred while removing user.");
+        } finally {
+            setUserToRemove(null);
         }
     };
 
@@ -257,6 +237,33 @@ export default function RecipientGroupDetailsScreen() {
                     ))
                 )}
             </ScrollView>
+
+            {/* Remove User Confirmation Modal */}
+            <Modal visible={!!userToRemove} animationType="fade" transparent>
+                <View style={styles.modalContainer}>
+                    <View style={[styles.modalContent, { backgroundColor: themeColors.card, alignItems: 'center' }]}>
+                        <Text style={[styles.modalTitle, { color: themeColors.text, marginBottom: 8 }]}>Remove User</Text>
+                        <Text style={{ color: themeColors.textSecondary, marginBottom: 20, textAlign: 'center' }}>
+                            Are you sure you want to remove this user from the group?
+                        </Text>
+                        
+                        <View style={{ flexDirection: 'row', justifyContent: 'center', width: '100%', gap: 16 }}>
+                            <TouchableOpacity 
+                                style={[styles.closeBtn, { backgroundColor: '#f0f0f0', borderRadius: 8, paddingHorizontal: 24 }]} 
+                                onPress={() => setUserToRemove(null)}
+                            >
+                                <Text style={{ color: '#333', fontWeight: 'bold' }}>Cancel</Text>
+                            </TouchableOpacity>
+                            <TouchableOpacity 
+                                style={[styles.confirmBtn, { backgroundColor: '#FF6B6B' }]} 
+                                onPress={confirmRemoveUser}
+                            >
+                                <Text style={styles.confirmText}>Remove</Text>
+                            </TouchableOpacity>
+                        </View>
+                    </View>
+                </View>
+            </Modal>
 
             {/* Advanced Add Member Modal */}
             <Modal visible={addMemberModalVisible} animationType="slide" transparent>

--- a/frontend/app/screens/researcher/RecipientGroupDetailsScreen.tsx
+++ b/frontend/app/screens/researcher/RecipientGroupDetailsScreen.tsx
@@ -133,38 +133,52 @@ export default function RecipientGroupDetailsScreen() {
     };
 
     const handleRemoveUser = async (userId: string) => {
+        console.log("[handleRemoveUser] Triggered for user:", userId);
+        
         const removeUserAction = async () => {
+            console.log("[handleRemoveUser] User confirmed removal. Proceeding with apiFetch...");
             try {
-                // New Endpoint: /api/v1/dashboard/recipients/{id}/update
-                // Payload: { removeUsernames: [userId] }
-                const res = await apiFetch(API_ENDPOINTS.researcher.RECIPIENTS_UPDATE(currentGroup.id), {
+                const url = API_ENDPOINTS.researcher.RECIPIENTS_UPDATE(currentGroup.id);
+                console.log("[handleRemoveUser] URL:", url);
+                
+                const res = await apiFetch(url, {
                     method: 'PUT',
                     headers: {
                         'Content-Type': 'application/json'
                     },
                     body: JSON.stringify({ removeUsernames: [userId] })
                 });
+                
+                console.log("[handleRemoveUser] apiFetch response status:", res.status);
+                
                 if (res.ok) {
+                    console.log("[handleRemoveUser] Successfully removed, refreshing group...");
                     refreshGroup();
                 } else {
+                    console.error("[handleRemoveUser] Failed to remove user. Status:", res.status);
                     Alert.alert("Error", "Failed to remove user");
                 }
             } catch (e) {
-                console.error(e);
+                console.error("[handleRemoveUser] Exception during fetch:", e);
+                Alert.alert("Error", "Network error occurred while removing user.");
             }
         };
 
         if (Platform.OS === 'web') {
+            console.log("[handleRemoveUser] Running on web, using window.confirm");
             if (window.confirm("Are you sure you want to remove this user from the group?")) {
                 removeUserAction();
+            } else {
+                console.log("[handleRemoveUser] User cancelled window.confirm");
             }
         } else {
+            console.log("[handleRemoveUser] Running on native, using Alert.alert");
             Alert.alert(
                 "Remove User",
                 "Are you sure you want to remove this user from the group?",
                 [
-                    { text: "Cancel", style: "cancel" },
-                    { text: "Remove", style: "destructive", onPress: removeUserAction }
+                    { text: "Cancel", style: "cancel", onPress: () => console.log("[handleRemoveUser] Cancelled") },
+                    { text: "OK", onPress: removeUserAction }
                 ]
             );
         }

--- a/frontend/app/screens/researcher/RecipientGroupDetailsScreen.tsx
+++ b/frontend/app/screens/researcher/RecipientGroupDetailsScreen.tsx
@@ -72,23 +72,19 @@ export default function RecipientGroupDetailsScreen() {
     };
 
     const handleAddSelected = async () => {
-        let finalUsernamesToAdd: string[] = [];
+        let finalUsernamesToAdd: string[] = [...selectedUserIds];
 
-        if (activeTab === 'USERS') {
-            finalUsernamesToAdd = selectedUserIds;
-        } else {
-            // Merge users from selected groups
-            const groupsToAdd = allGroups.filter((g: any) => selectedGroupIds.includes(g.id));
-            groupsToAdd.forEach((g: any) => {
-                g.users.forEach((u: any) => {
-                    if (!currentGroup.users.some((existing: any) => existing.id === u.id)) {
-                        finalUsernamesToAdd.push(u.id);
-                    }
-                });
+        // Merge users from selected groups
+        const groupsToAdd = allGroups.filter((g: any) => selectedGroupIds.includes(g.id));
+        groupsToAdd.forEach((g: any) => {
+            g.users.forEach((u: any) => {
+                if (!currentGroup.users.some((existing: any) => existing.id === u.id)) {
+                    finalUsernamesToAdd.push(u.id);
+                }
             });
-            // Unique IDs only
-            finalUsernamesToAdd = Array.from(new Set(finalUsernamesToAdd));
-        }
+        });
+        // Unique IDs only
+        finalUsernamesToAdd = Array.from(new Set(finalUsernamesToAdd));
 
         if (finalUsernamesToAdd.length === 0) {
             setAddMemberModalVisible(false);
@@ -100,6 +96,9 @@ export default function RecipientGroupDetailsScreen() {
             // Payload: { addUsernames: [...] }
             const res = await apiFetch(API_ENDPOINTS.researcher.RECIPIENTS_UPDATE(currentGroup.id), {
                 method: 'PUT',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
                 body: JSON.stringify({ addUsernames: finalUsernamesToAdd })
             });
 
@@ -147,6 +146,9 @@ export default function RecipientGroupDetailsScreen() {
                             // Payload: { removeUsernames: [userId] }
                             const res = await apiFetch(API_ENDPOINTS.researcher.RECIPIENTS_UPDATE(currentGroup.id), {
                                 method: 'PUT',
+                                headers: {
+                                    'Content-Type': 'application/json'
+                                },
                                 body: JSON.stringify({ removeUsernames: [userId] })
                             });
                             if (res.ok) {

--- a/frontend/app/screens/researcher/RecipientGroupDetailsScreen.tsx
+++ b/frontend/app/screens/researcher/RecipientGroupDetailsScreen.tsx
@@ -8,7 +8,8 @@ import {
     StyleSheet,
     Text,
     TouchableOpacity,
-    View
+    View,
+    Platform
 } from 'react-native';
 import { Colors } from '../../../constants/theme';
 import { apiFetch } from '../../api/apiFetch';
@@ -132,37 +133,41 @@ export default function RecipientGroupDetailsScreen() {
     };
 
     const handleRemoveUser = async (userId: string) => {
-        Alert.alert(
-            "Remove User",
-            "Are you sure you want to remove this user from the group?",
-            [
-                { text: "Cancel", style: "cancel" },
-                {
-                    text: "Remove",
-                    style: "destructive",
-                    onPress: async () => {
-                        try {
-                            // New Endpoint: /api/v1/dashboard/recipients/{id}/update
-                            // Payload: { removeUsernames: [userId] }
-                            const res = await apiFetch(API_ENDPOINTS.researcher.RECIPIENTS_UPDATE(currentGroup.id), {
-                                method: 'PUT',
-                                headers: {
-                                    'Content-Type': 'application/json'
-                                },
-                                body: JSON.stringify({ removeUsernames: [userId] })
-                            });
-                            if (res.ok) {
-                                refreshGroup();
-                            } else {
-                                Alert.alert("Error", "Failed to remove user");
-                            }
-                        } catch (e) {
-                            console.error(e);
-                        }
-                    }
+        const removeUserAction = async () => {
+            try {
+                // New Endpoint: /api/v1/dashboard/recipients/{id}/update
+                // Payload: { removeUsernames: [userId] }
+                const res = await apiFetch(API_ENDPOINTS.researcher.RECIPIENTS_UPDATE(currentGroup.id), {
+                    method: 'PUT',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({ removeUsernames: [userId] })
+                });
+                if (res.ok) {
+                    refreshGroup();
+                } else {
+                    Alert.alert("Error", "Failed to remove user");
                 }
-            ]
-        );
+            } catch (e) {
+                console.error(e);
+            }
+        };
+
+        if (Platform.OS === 'web') {
+            if (window.confirm("Are you sure you want to remove this user from the group?")) {
+                removeUserAction();
+            }
+        } else {
+            Alert.alert(
+                "Remove User",
+                "Are you sure you want to remove this user from the group?",
+                [
+                    { text: "Cancel", style: "cancel" },
+                    { text: "Remove", style: "destructive", onPress: removeUserAction }
+                ]
+            );
+        }
     };
 
     // --- Composition Logic ---


### PR DESCRIPTION
# Root Cause Analysis & Fixes

## 1. Users not saving when creating a new list (0 users unless groups are selected)

### Root Cause
The backend `RecipientGroupService` used:

```java
recipientUserRepository.findByUsernameIn(...)
```

to retrieve users before assigning them to a group.

However, if a user did not already exist in the `recipient_users` table, the query returned nothing for that username, silently skipping it.

Selecting a group appeared to work because those users were already guaranteed to exist in the `recipient_users` table.

### Fix
Updated `RecipientGroupService.java` to:

- Detect usernames that do not yet exist in `recipient_users`
- Automatically create and persist missing `RecipientUser` entities
- Assign the newly created users to the recipient group

---

## 2. `No static resource api/v1/dashboard/recipients/{id}/update` (500 error when adding/removing users)

### Root Cause
There was a route mismatch between the frontend and backend.

Frontend (`apiEndpoints.ts`) expected:

```text
/api/v1/dashboard/recipients/{groupId}/update
```

Backend (`RecipientsGroupController`) exposed:

```text
PUT /api/v1/dashboard/recipients/{groupId}
```

(without the `/update` suffix)

### Fix
Removed the `/update` suffix from the `RECIPIENTS_UPDATE` constant in `apiEndpoints.ts` so the frontend correctly matches the backend endpoint.

---

## 3. "Delete user button not working" / "Adding members not working" (request payload ignored)

### Root Cause
Frontend `PUT` requests for updating recipient groups sent JSON payloads but omitted:

```http
Content-Type: application/json
```

Because `apiFetch` does not automatically attach this header for `PUT` requests, the Spring Boot backend ignored the request body entirely.

### Fix
Added explicit JSON headers to both add/remove member API calls in `RecipientGroupDetailsScreen.tsx`:

```ts
headers: {
  'Content-Type': 'application/json'
}
```

---

## 4. Groups not included when selecting users to add in the Details Screen

### Root Cause
In `RecipientGroupDetailsScreen.tsx`, the `handleAddSelected` logic used an `if/else` block based on `activeTab`.

As a result:

- Selecting from the `"USERS"` tab ignored selected groups
- Selecting from the `"GROUPS"` tab ignored selected users

### Fix
Refactored the logic to always merge:

- `selectedUserIds`
- Users resolved from `selectedGroupIds`

This now behaves consistently with the implementation in `RecipientsListScreen.tsx`.

---

# Additional Backend Fix – `removeUser` failing silently

## Root Cause
The backend issue was caused by a classic JPA/Hibernate collection equality problem.

`RecipientGroup` stores users as:

```java
Set<RecipientUser> users
```

The removal logic previously relied on:

```java
users.removeAll(usersToRemove)
```

However, `RecipientUser` used Lombok's `@Data`, which auto-generated `equals()` and `hashCode()` using all fields.

Because Hibernate frequently wraps entities in proxy objects during lazy loading, object equality comparisons failed, causing:

```java
removeAll()
```

to silently do nothing.

As a result:

- The collection appeared unchanged
- Hibernate did not persist any deletion
- Users remained in the group

## Fix

### `RecipientGroup.java`
Rewrote `removeUsers()` to remove users explicitly by their database identifier (`username`) instead of relying on Java object equality.

### `RecipientUser.java`
Replaced the Lombok `@Data` equality behavior with:

```java
@EqualsAndHashCode(onlyExplicitlyIncluded = true)
```

and explicitly included:

```java
@EqualsAndHashCode.Include
private String username;
```

This ensures:

- Equality comparisons rely strictly on the entity ID
- Hibernate proxy objects no longer break `Set` operations
- Future collection operations remain stable and predictable

---

# UX Improvement – Custom Remove User Confirmation Modal

Implemented a custom in-app confirmation modal directly inside `RecipientGroupDetailsScreen`.

## Behavior
Clicking the 🗑️ remove button now opens a styled React Native modal asking:

> "Are you sure you want to remove this user from the group?"

## Benefits

- Consistent app styling
- Works reliably across:
  - Web
  - iOS
  - Android
- Avoids native dialog inconsistencies
- Prevents API calls from being blocked by platform-specific dialog behavior

Once confirmed, the removal request is processed immediately.

---

# Modified Files Summary

## Backend
- `RecipientGroupService.java`
  - Added automatic creation of missing users
- `RecipientGroup.java`
  - Reworked user removal logic to remove by ID
- `RecipientUser.java`
  - Fixed entity equality/hashCode implementation

## Frontend
- `apiEndpoints.ts`
  - Fixed incorrect PUT route mapping
- `RecipientGroupDetailsScreen.tsx`
  - Added `Content-Type: application/json` headers
  - Fixed merging logic for selected users/groups
  - Added custom remove confirmation modal