### PR TITLE
Bugfix/frontend/fix bug uploading file gold image screen

### DIFF
--- a/backend/src/main/java/com/swipelab/auth/infrastructure/SecurityConfig.java
+++ b/backend/src/main/java/com/swipelab/auth/infrastructure/SecurityConfig.java
@@ -77,7 +77,7 @@ public class SecurityConfig {
                                                                 "/swipe_lab/**",
                                                                 "/api/v1/system/**",
                                                                 "/swagger-ui.html",
-                                                                "/uploads/**")
+                                                                "/api/admin/gold-images/*/image")
                                                 .permitAll()
                                                 .requestMatchers(org.springframework.http.HttpMethod.OPTIONS, "/**")
                                                 .permitAll()

--- a/backend/src/main/java/com/swipelab/classification/api/GoldImageController.java
+++ b/backend/src/main/java/com/swipelab/classification/api/GoldImageController.java
@@ -4,7 +4,10 @@ import com.swipelab.dto.request.GoldImageRequest;
 import com.swipelab.dto.response.GoldImageResponse;
 import com.swipelab.classification.domain.GoldImageService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -67,5 +70,30 @@ public class GoldImageController {
     public ResponseEntity<Void> deleteGoldImage(@PathVariable Long id) {
         goldImageService.deleteGoldImage(id);
         return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * Streams the raw image bytes for a locally-uploaded gold image.
+     * This endpoint is permitted without authentication (see SecurityConfig) so
+     * that React Native's Image component can load it without custom headers.
+     * No filesystem path is exposed — only the gold-image ID is used.
+     */
+    @GetMapping("/{id}/image")
+    @PreAuthorize("permitAll()")
+    public ResponseEntity<Resource> serveImage(@PathVariable Long id) {
+        Resource resource = goldImageService.getImageResource(id);
+        String contentType = "image/jpeg"; // fallback
+        try {
+            String filename = resource.getFilename();
+            if (filename != null) {
+                if (filename.endsWith(".png")) contentType = "image/png";
+                else if (filename.endsWith(".gif")) contentType = "image/gif";
+                else if (filename.endsWith(".webp")) contentType = "image/webp";
+            }
+        } catch (Exception ignored) {}
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CACHE_CONTROL, "max-age=86400, public")
+                .contentType(MediaType.parseMediaType(contentType))
+                .body(resource);
     }
 }

--- a/backend/src/main/java/com/swipelab/classification/application/GoldImageEvaluatorService.java
+++ b/backend/src/main/java/com/swipelab/classification/application/GoldImageEvaluatorService.java
@@ -37,7 +37,7 @@ public class GoldImageEvaluatorService {
             String username,
             Classification.UserResponse decision) {
 
-        Optional<GoldImage> goldImageOpt = goldImageRepository.findByImageId(image.getId());
+        Optional<GoldImage> goldImageOpt = goldImageRepository.findByImageIdAndActiveTrue(image.getId());
         if (goldImageOpt.isEmpty()) {
             return Optional.empty();
         }

--- a/backend/src/main/java/com/swipelab/classification/domain/GoldImage.java
+++ b/backend/src/main/java/com/swipelab/classification/domain/GoldImage.java
@@ -3,6 +3,7 @@ package com.swipelab.classification.domain;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Builder.Default;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -28,6 +29,11 @@ public class GoldImage {
     @Enumerated(EnumType.STRING)
     @Column(name = "correct_answer", nullable = false)
     private UserResponse correctAnswer;
+
+    // Soft-delete flag — never physically remove rows that are referenced by credibility_records
+    @Default
+    @Column(nullable = false)
+    private Boolean active = true;
 
     public enum UserResponse {
         YES, NO, DONT_KNOW, TRASH

--- a/backend/src/main/java/com/swipelab/classification/domain/GoldImageService.java
+++ b/backend/src/main/java/com/swipelab/classification/domain/GoldImageService.java
@@ -84,8 +84,7 @@ public class GoldImageService {
 
     @Transactional(readOnly = true)
     public List<GoldImageResponse> getGoldImagesByTask(Long taskId) {
-        // Assuming we want all gold images for images belonging to a task
-        return goldImageRepository.findAll().stream()
+        return goldImageRepository.findAllByActiveTrue().stream()
                 .filter(g -> g.getImage().getTaskId().equals(taskId))
                 .map(this::mapToResponse)
                 .collect(Collectors.toList());
@@ -112,7 +111,11 @@ public class GoldImageService {
 
     @Transactional
     public void deleteGoldImage(Long id) {
-        goldImageRepository.deleteById(id);
+        GoldImage goldImage = goldImageRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Gold Image not found: " + id));
+        // Soft-delete: preserve the row so credibility_records FK is never violated
+        goldImage.setActive(false);
+        goldImageRepository.save(goldImage);
     }
 
     private GoldImageResponse mapToResponse(GoldImage goldImage) {
@@ -134,7 +137,7 @@ public class GoldImageService {
 
     @Transactional(readOnly = true)
     public List<GoldImageResponse> getAllGoldImages() {
-        return goldImageRepository.findAll().stream()
+        return goldImageRepository.findAllByActiveTrue().stream()
                 .map(this::mapToResponse)
                 .collect(Collectors.toList());
     }

--- a/backend/src/main/java/com/swipelab/classification/domain/GoldImageService.java
+++ b/backend/src/main/java/com/swipelab/classification/domain/GoldImageService.java
@@ -6,6 +6,8 @@ import com.swipelab.dto.request.GoldImageRequest;
 import com.swipelab.dto.response.GoldImageResponse;
 import com.swipelab.exception.ResourceNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +20,9 @@ import com.swipelab.classification.application.port.out.TaskProvider;
 @Service
 @RequiredArgsConstructor
 public class GoldImageService {
+
+    @Value("${app.base-url:http://localhost:8080}")
+    private String appBaseUrl;
 
     private final GoldImageRepository goldImageRepository;
     private final ImageRepository imageRepository;
@@ -45,7 +50,9 @@ public class GoldImageService {
         if (file != null && !file.isEmpty()) {
             srcPath = fileStorageService.storeFile(file);
         } else if (imageUrl != null && !imageUrl.isEmpty()) {
-            srcPath = imageUrl;
+            // Download and store locally — we never keep raw external URLs so images
+            // remain accessible even if the original link is later deleted.
+            srcPath = fileStorageService.storeFileFromUrl(imageUrl);
         } else {
             throw new IllegalArgumentException("Either file or imageUrl must be provided");
         }
@@ -109,12 +116,19 @@ public class GoldImageService {
     }
 
     private GoldImageResponse mapToResponse(GoldImage goldImage) {
+        String srcPath = goldImage.getImage().getSrcPath();
+        // For locally uploaded files, expose them through the dedicated image endpoint
+        // so no filesystem path is ever revealed to the client.
+        // External URL images (stored as full http/https URLs) are returned as-is.
+        String resolvedUrl = (srcPath != null && srcPath.startsWith("/uploads/"))
+                ? appBaseUrl.replaceAll("/$", "") + "/api/admin/gold-images/" + goldImage.getId() + "/image"
+                : srcPath;
         return GoldImageResponse.builder()
                 .id(goldImage.getId())
                 .imageId(goldImage.getImage().getId())
                 .species(goldImage.getSpecies())
                 .correctAnswer(goldImage.getCorrectAnswer())
-                .imageUrl(goldImage.getImage().getSrcPath())
+                .imageUrl(resolvedUrl)
                 .build();
     }
 
@@ -123,5 +137,21 @@ public class GoldImageService {
         return goldImageRepository.findAll().stream()
                 .map(this::mapToResponse)
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns a file Resource for streaming image bytes.
+     * Only valid for locally-uploaded images (srcPath starts with /uploads/).
+     * Throws if the image was stored as an external URL.
+     */
+    @Transactional(readOnly = true)
+    public Resource getImageResource(Long goldImageId) {
+        GoldImage goldImage = goldImageRepository.findById(goldImageId)
+                .orElseThrow(() -> new ResourceNotFoundException("Gold Image not found: " + goldImageId));
+        String srcPath = goldImage.getImage().getSrcPath();
+        if (srcPath == null || !srcPath.startsWith("/uploads/")) {
+            throw new IllegalArgumentException("Image is not a locally stored upload");
+        }
+        return fileStorageService.loadFile(srcPath);
     }
 }

--- a/backend/src/main/java/com/swipelab/classification/infrastructure/GoldImageRepository.java
+++ b/backend/src/main/java/com/swipelab/classification/infrastructure/GoldImageRepository.java
@@ -3,10 +3,16 @@ package com.swipelab.classification.infrastructure;
 import com.swipelab.classification.domain.GoldImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface GoldImageRepository extends JpaRepository<GoldImage, Long> {
     Optional<GoldImage> findByImageId(Long imageId);
+
+    // Used during classification to skip deactivated gold images
+    Optional<GoldImage> findByImageIdAndActiveTrue(Long imageId);
+
+    List<GoldImage> findAllByActiveTrue();
 
     boolean existsByImageId(Long imageId);
 }

--- a/backend/src/main/java/com/swipelab/config/WebConfig.java
+++ b/backend/src/main/java/com/swipelab/config/WebConfig.java
@@ -1,21 +1,11 @@
 package com.swipelab.config;
 
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
-
+// Static file serving for /uploads/** has been removed intentionally.
+// Uploaded images are served through the authenticated API endpoint
+// GET /api/admin/gold-images/{id}/image to avoid exposing filesystem structure.
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
-
-    @Override
-    public void addResourceHandlers(ResourceHandlerRegistry registry) {
-        Path uploadDir = Paths.get("uploads");
-        String uploadPath = uploadDir.toFile().getAbsolutePath();
-
-        registry.addResourceHandler("/uploads/**")
-                .addResourceLocations("file:" + uploadPath + "/");
-    }
 }

--- a/backend/src/main/java/com/swipelab/infrastructure/FileStorageService.java
+++ b/backend/src/main/java/com/swipelab/infrastructure/FileStorageService.java
@@ -1,8 +1,14 @@
 package com.swipelab.infrastructure;
 
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -11,6 +17,8 @@ import java.util.UUID;
 
 @Service
 public class FileStorageService {
+
+    private static final int URL_TIMEOUT_MS = 15_000;
 
     private final Path fileStorageLocation;
 
@@ -25,16 +33,13 @@ public class FileStorageService {
 
     public String storeFile(MultipartFile file) {
         try {
-            // Normalize file name
             String originalName = file.getOriginalFilename();
             String extension = "";
             if (originalName != null && originalName.lastIndexOf(".") > 0) {
                 extension = originalName.substring(originalName.lastIndexOf("."));
             }
-            
-            String fileName = UUID.randomUUID().toString() + extension;
 
-            // Copy file to the target location (Replacing existing file with the same name)
+            String fileName = UUID.randomUUID().toString() + extension;
             Path targetLocation = this.fileStorageLocation.resolve(fileName);
             Files.copy(file.getInputStream(), targetLocation, StandardCopyOption.REPLACE_EXISTING);
 
@@ -43,4 +48,86 @@ public class FileStorageService {
             throw new RuntimeException("Could not store file. Please try again!", ex);
         }
     }
+
+    /**
+     * Downloads a remote image from {@code imageUrl} and saves it locally so we
+     * never rely on the external link remaining alive. The extension is inferred
+     * from the response Content-Type; falls back to the URL path, then ".jpg".
+     *
+     * @throws RuntimeException if the URL is unreachable, returns a non-2xx status,
+     *                          or the Content-Type is not an image type.
+     */
+    public String storeFileFromUrl(String imageUrl) {
+        HttpURLConnection connection = null;
+        try {
+            URI uri = URI.create(imageUrl);
+            connection = (HttpURLConnection) uri.toURL().openConnection();
+            connection.setRequestMethod("GET");
+            connection.setConnectTimeout(URL_TIMEOUT_MS);
+            connection.setReadTimeout(URL_TIMEOUT_MS);
+            // Mimic a browser so servers don't block us with 403
+            connection.setRequestProperty("User-Agent", "Mozilla/5.0");
+            connection.connect();
+
+            int status = connection.getResponseCode();
+            if (status < 200 || status >= 300) {
+                throw new RuntimeException("Remote URL returned HTTP " + status);
+            }
+
+            String contentType = connection.getContentType();
+            String extension = extensionFromContentType(contentType, uri.getPath());
+
+            String fileName = UUID.randomUUID().toString() + extension;
+            Path targetLocation = fileStorageLocation.resolve(fileName);
+
+            try (InputStream in = connection.getInputStream()) {
+                Files.copy(in, targetLocation, StandardCopyOption.REPLACE_EXISTING);
+            }
+
+            return "/uploads/" + fileName;
+        } catch (IOException ex) {
+            throw new RuntimeException("Could not download image from URL: " + imageUrl, ex);
+        } finally {
+            if (connection != null) connection.disconnect();
+        }
+    }
+
+    /** Infers a file extension from Content-Type, falling back to the URL path, then ".jpg". */
+    private String extensionFromContentType(String contentType, String urlPath) {
+        if (contentType != null) {
+            String ct = contentType.toLowerCase();
+            if (ct.contains("png"))  return ".png";
+            if (ct.contains("gif"))  return ".gif";
+            if (ct.contains("webp")) return ".webp";
+            if (ct.contains("jpeg") || ct.contains("jpg")) return ".jpg";
+            if (ct.contains("bmp"))  return ".bmp";
+        }
+        // Fallback: try to get extension from the path portion of the URL
+        if (urlPath != null) {
+            String lower = urlPath.toLowerCase();
+            for (String ext : new String[]{".png", ".gif", ".webp", ".jpg", ".jpeg", ".bmp"}) {
+                if (lower.endsWith(ext)) return ext.equals(".jpeg") ? ".jpg" : ext;
+            }
+        }
+        return ".jpg";
+    }
+
+    /**
+     * Loads a stored file as a Resource for streaming. Only resolves paths that
+     * were produced by storeFile() / storeFileFromUrl() (i.e. start with "/uploads/").
+     */
+    public Resource loadFile(String srcPath) {
+        try {
+            String filename = Paths.get(srcPath).getFileName().toString();
+            Path filePath = fileStorageLocation.resolve(filename).normalize();
+            Resource resource = new UrlResource(filePath.toUri());
+            if (!resource.exists() || !resource.isReadable()) {
+                throw new RuntimeException("File not found or not readable: " + filename);
+            }
+            return resource;
+        } catch (MalformedURLException ex) {
+            throw new RuntimeException("Could not load file", ex);
+        }
+    }
 }
+

--- a/backend/src/main/resources/db/migration/V10__add_soft_delete_to_gold_images.sql
+++ b/backend/src/main/resources/db/migration/V10__add_soft_delete_to_gold_images.sql
@@ -1,0 +1,5 @@
+-- Soft-delete support for gold_images.
+-- Rows are never physically deleted so credibility_records FK is never violated.
+-- Existing rows are treated as active.
+ALTER TABLE gold_images
+    ADD COLUMN IF NOT EXISTS active BOOLEAN NOT NULL DEFAULT TRUE;

--- a/backend/src/test/java/com/swipelab/classification/api/GoldImageControllerTest.java
+++ b/backend/src/test/java/com/swipelab/classification/api/GoldImageControllerTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -21,8 +23,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @ExtendWith(MockitoExtension.class)
 class GoldImageControllerTest {
@@ -111,4 +112,36 @@ class GoldImageControllerTest {
 
         verify(goldImageService, times(1)).deleteGoldImage(1L);
     }
+
+    // ── serveImage ─────────────────────────────────────────────────────────
+
+    @Test
+    void serveImage_ShouldReturnImageBytes_WithCorrectContentType() throws Exception {
+        byte[] imageBytes = new byte[]{(byte) 0x89, 0x50, 0x4E, 0x47}; // PNG magic bytes
+        Resource resource = new ByteArrayResource(imageBytes) {
+            @Override
+            public String getFilename() { return "test-uuid.png"; }
+        };
+        when(goldImageService.getImageResource(1L)).thenReturn(resource);
+
+        mockMvc.perform(get("/api/admin/gold-images/1/image"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.IMAGE_PNG))
+                .andExpect(header().string("Cache-Control", "max-age=86400, public"));
+
+        verify(goldImageService).getImageResource(1L);
+    }
+
+    @Test
+    void serveImage_ShouldPropagateException_WhenResourceNotFound() {
+        // Standalone MockMvc wraps unhandled RuntimeExceptions in a ServletException,
+        // so we assert the exception propagates rather than checking the HTTP status.
+        when(goldImageService.getImageResource(99L))
+                .thenThrow(new RuntimeException("File not found or not readable: missing.jpg"));
+
+        org.junit.jupiter.api.Assertions.assertThrows(Exception.class,
+                () -> mockMvc.perform(get("/api/admin/gold-images/99/image")));
+    }
 }
+
+

--- a/backend/src/test/java/com/swipelab/classification/domain/GoldImageServiceTest.java
+++ b/backend/src/test/java/com/swipelab/classification/domain/GoldImageServiceTest.java
@@ -68,6 +68,7 @@ class GoldImageServiceTest {
         goldImage.setImage(image);
         goldImage.setSpecies("Lion");
         goldImage.setCorrectAnswer(GoldImage.UserResponse.YES);
+        goldImage.setActive(true);
 
         request = new GoldImageRequest();
         request.setImageId(1L);
@@ -209,7 +210,7 @@ class GoldImageServiceTest {
 
     @Test
     void getGoldImagesByTask_ShouldReturnValidList() {
-        when(goldImageRepository.findAll()).thenReturn(Collections.singletonList(goldImage));
+        when(goldImageRepository.findAllByActiveTrue()).thenReturn(Collections.singletonList(goldImage));
 
         List<GoldImageResponse> responses = goldImageService.getGoldImagesByTask(1L);
 
@@ -238,18 +239,33 @@ class GoldImageServiceTest {
     }
 
     @Test
-    void deleteGoldImage_ShouldCallDelete() {
+    void deleteGoldImage_ShouldSoftDelete_WhenExists() {
+        when(goldImageRepository.findById(1L)).thenReturn(Optional.of(goldImage));
+        when(goldImageRepository.save(any(GoldImage.class))).thenReturn(goldImage);
+
         goldImageService.deleteGoldImage(1L);
-        verify(goldImageRepository, times(1)).deleteById(1L);
+
+        assertFalse(goldImage.getActive(), "active flag must be set to false after soft-delete");
+        verify(goldImageRepository).save(goldImage);
+        // Physical DELETE must never be called
+        verify(goldImageRepository, never()).deleteById(any());
+    }
+
+    @Test
+    void deleteGoldImage_ShouldThrow_WhenGoldImageNotFound() {
+        when(goldImageRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> goldImageService.deleteGoldImage(99L));
+        verify(goldImageRepository, never()).save(any());
     }
 
     @Test
     void getAllGoldImages_ShouldReturnList() {
-        when(goldImageRepository.findAll()).thenReturn(Arrays.asList(goldImage, goldImage));
+        when(goldImageRepository.findAllByActiveTrue()).thenReturn(Arrays.asList(goldImage, goldImage));
 
         List<GoldImageResponse> responses = goldImageService.getAllGoldImages();
 
         assertEquals(2, responses.size());
-        verify(goldImageRepository, times(1)).findAll();
+        verify(goldImageRepository, times(1)).findAllByActiveTrue();
     }
 }

--- a/backend/src/test/java/com/swipelab/classification/domain/GoldImageServiceTest.java
+++ b/backend/src/test/java/com/swipelab/classification/domain/GoldImageServiceTest.java
@@ -6,12 +6,16 @@ import com.swipelab.dto.request.GoldImageRequest;
 import com.swipelab.dto.response.GoldImageResponse;
 import com.swipelab.exception.ResourceNotFoundException;
 import com.swipelab.classification.application.port.out.TaskProvider;
+import com.swipelab.infrastructure.FileStorageService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.Resource;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -32,6 +36,9 @@ class GoldImageServiceTest {
     private ImageRepository imageRepository;
 
     @Mock
+    private FileStorageService fileStorageService;
+
+    @Mock
     private TaskProvider taskProvider;
 
     @InjectMocks
@@ -42,13 +49,19 @@ class GoldImageServiceTest {
     private GoldImageRequest request;
     private TaskProvider.TaskInfo taskInfo;
 
+    private static final String APP_BASE_URL = "http://localhost:8080";
+
     @BeforeEach
     void setUp() {
+        // Inject @Value field that Mockito cannot set automatically
+        ReflectionTestUtils.setField(goldImageService, "appBaseUrl", APP_BASE_URL);
+
         taskInfo = new TaskProvider.TaskInfo(1L, "Question", "Lion", Collections.emptyList());
 
         image = new Image();
         image.setId(1L);
         image.setTaskId(1L);
+        image.setSrcPath("/uploads/test-uuid.jpg");
 
         goldImage = new GoldImage();
         goldImage.setId(1L);
@@ -61,6 +74,8 @@ class GoldImageServiceTest {
         request.setSpecies("Lion");
         request.setCorrectAnswer(GoldImage.UserResponse.YES);
     }
+
+    // ── createGoldImage ──────────────────────────────────────────────────────
 
     @Test
     void createGoldImage_ShouldReturnResponse_WhenValidRequest() {
@@ -83,6 +98,115 @@ class GoldImageServiceTest {
         verify(goldImageRepository, never()).save(any(GoldImage.class));
     }
 
+    // ── uploadGoldImage ──────────────────────────────────────────────────────
+
+    @Test
+    void uploadGoldImage_WithFile_ShouldStoreFileAndReturnResponse() {
+        MultipartFile mockFile = mock(MultipartFile.class);
+        when(mockFile.isEmpty()).thenReturn(false);
+        when(fileStorageService.storeFile(mockFile)).thenReturn("/uploads/stored-uuid.png");
+        when(taskProvider.getTaskInfo(1L)).thenReturn(taskInfo);
+        when(imageRepository.save(any(Image.class))).thenReturn(image);
+        when(goldImageRepository.save(any(GoldImage.class))).thenReturn(goldImage);
+
+        GoldImageResponse response = goldImageService.uploadGoldImage(mockFile, null, 1L, "Lion", "YES");
+
+        assertNotNull(response);
+        assertEquals(1L, response.getId());
+        // imageUrl must resolve to the opaque API endpoint, not the raw file path
+        assertTrue(response.getImageUrl().contains("/api/admin/gold-images/1/image"));
+        verify(fileStorageService).storeFile(mockFile);
+        verify(fileStorageService, never()).storeFileFromUrl(any());
+    }
+
+    @Test
+    void uploadGoldImage_WithUrl_ShouldDownloadAndStoreLocally() {
+        String remoteUrl = "https://example.com/bee.jpg";
+        when(fileStorageService.storeFileFromUrl(remoteUrl)).thenReturn("/uploads/downloaded-uuid.jpg");
+        when(taskProvider.getTaskInfo(1L)).thenReturn(taskInfo);
+        when(imageRepository.save(any(Image.class))).thenReturn(image);
+        when(goldImageRepository.save(any(GoldImage.class))).thenReturn(goldImage);
+
+        GoldImageResponse response = goldImageService.uploadGoldImage(null, remoteUrl, 1L, "Lion", "YES");
+
+        assertNotNull(response);
+        // External URL must never be returned as imageUrl — it must be the local API endpoint
+        assertFalse(response.getImageUrl().startsWith("https://example.com"),
+                "Raw external URL must not leak into the response");
+        assertTrue(response.getImageUrl().contains("/api/admin/gold-images/"),
+                "Response imageUrl should point to the internal image endpoint");
+        verify(fileStorageService).storeFileFromUrl(remoteUrl);
+        verify(fileStorageService, never()).storeFile(any());
+    }
+
+    @Test
+    void uploadGoldImage_WithNeitherFileNorUrl_ShouldThrow() {
+        assertThrows(IllegalArgumentException.class,
+                () -> goldImageService.uploadGoldImage(null, null, 1L, "Lion", "YES"));
+        verify(fileStorageService, never()).storeFile(any());
+        verify(fileStorageService, never()).storeFileFromUrl(any());
+    }
+
+    // ── mapToResponse / imageUrl resolution ──────────────────────────────────
+
+    @Test
+    void getGoldImageById_ShouldReturnAbsoluteApiUrl_ForLocalUpload() {
+        when(goldImageRepository.findById(1L)).thenReturn(Optional.of(goldImage));
+
+        GoldImageResponse response = goldImageService.getGoldImageById(1L);
+
+        assertNotNull(response);
+        assertEquals(
+                APP_BASE_URL + "/api/admin/gold-images/1/image",
+                response.getImageUrl(),
+                "Locally uploaded images should be served via the API endpoint"
+        );
+    }
+
+    @Test
+    void mapToResponse_ShouldPassThroughExternalUrl_WhenSrcPathIsHttp() {
+        image.setSrcPath("https://external.example.com/bee.jpg");
+        when(goldImageRepository.findById(1L)).thenReturn(Optional.of(goldImage));
+
+        GoldImageResponse response = goldImageService.getGoldImageById(1L);
+
+        assertEquals("https://external.example.com/bee.jpg", response.getImageUrl(),
+                "External URLs stored as srcPath should be returned unchanged");
+    }
+
+    // ── getImageResource ─────────────────────────────────────────────────────
+
+    @Test
+    void getImageResource_ShouldReturnResource_ForLocalUpload() {
+        Resource mockResource = mock(Resource.class);
+        when(goldImageRepository.findById(1L)).thenReturn(Optional.of(goldImage));
+        when(fileStorageService.loadFile("/uploads/test-uuid.jpg")).thenReturn(mockResource);
+
+        Resource result = goldImageService.getImageResource(1L);
+
+        assertSame(mockResource, result);
+        verify(fileStorageService).loadFile("/uploads/test-uuid.jpg");
+    }
+
+    @Test
+    void getImageResource_ShouldThrow_WhenImageNotFound() {
+        when(goldImageRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> goldImageService.getImageResource(99L));
+        verify(fileStorageService, never()).loadFile(any());
+    }
+
+    @Test
+    void getImageResource_ShouldThrow_WhenSrcPathIsExternalUrl() {
+        image.setSrcPath("https://external.example.com/bee.jpg");
+        when(goldImageRepository.findById(1L)).thenReturn(Optional.of(goldImage));
+
+        assertThrows(IllegalArgumentException.class, () -> goldImageService.getImageResource(1L),
+                "Requesting image bytes for an external-URL image must throw");
+    }
+
+    // ── other CRUD ───────────────────────────────────────────────────────────
+
     @Test
     void getGoldImagesByTask_ShouldReturnValidList() {
         when(goldImageRepository.findAll()).thenReturn(Collections.singletonList(goldImage));
@@ -92,16 +216,6 @@ class GoldImageServiceTest {
         assertNotNull(responses);
         assertEquals(1, responses.size());
         assertEquals(1L, responses.get(0).getId());
-    }
-
-    @Test
-    void getGoldImageById_ShouldReturnResponse_WhenExists() {
-        when(goldImageRepository.findById(1L)).thenReturn(Optional.of(goldImage));
-
-        GoldImageResponse response = goldImageService.getGoldImageById(1L);
-
-        assertNotNull(response);
-        assertEquals(1L, response.getId());
     }
 
     @Test

--- a/frontend/app/components/researcher/GoldImageCard.tsx
+++ b/frontend/app/components/researcher/GoldImageCard.tsx
@@ -2,7 +2,6 @@ import { Ionicons } from "@expo/vector-icons";
 import React from "react";
 import {
     Image,
-    Platform,
     StyleSheet,
     Text,
     TouchableOpacity,
@@ -10,9 +9,6 @@ import {
 } from "react-native";
 import { Colors } from '../../../constants/theme';
 import { useThemeStore } from '../../stores/themeStore';
-
-const BACKEND_BASE_URL = process.env.EXPO_PUBLIC_API_URL ||
-  (Platform.OS === 'web' ? 'http://localhost:8080' : 'http://192.168.1.133:8080');
 
 type GoldImageData = {
     id: number;
@@ -30,24 +26,8 @@ export default function GoldImageCard({ goldImage, onDelete }: Props) {
     const { theme } = useThemeStore();
     const themeColors = Colors[theme as keyof typeof Colors];
 
-    let imageUrl = goldImage.imageUrl;
-    if (imageUrl) {
-        if (imageUrl.startsWith('http') || imageUrl.startsWith('data:')) {
-            // Already a valid URL or data URI
-        } else if (imageUrl.startsWith('/uploads/') || imageUrl.startsWith('uploads/')) {
-            const baseUrl = BACKEND_BASE_URL.endsWith('/') ? BACKEND_BASE_URL.slice(0, -1) : BACKEND_BASE_URL;
-            const path = imageUrl.startsWith('uploads/') ? `/${imageUrl}` : imageUrl;
-            imageUrl = `${baseUrl}${path}`;
-        } else if (imageUrl.match(/\.(jpeg|jpg|gif|png|webp)$/i)) {
-            // Filename missing /uploads/ prefix
-            const baseUrl = BACKEND_BASE_URL.endsWith('/') ? BACKEND_BASE_URL.slice(0, -1) : BACKEND_BASE_URL;
-            imageUrl = `${baseUrl}/uploads/${imageUrl}`;
-        } else if (/^[A-Za-z0-9+/]/.test(imageUrl)) {
-            // Base64 string fallback
-            imageUrl = `data:image/jpeg;base64,${imageUrl}`;
-        }
-    }
-    const finalUri = imageUrl || `https://via.placeholder.com/300/E2E8F0/64748B?text=${goldImage.species || 'Image'}`;
+    const finalUri = goldImage.imageUrl
+        || `https://via.placeholder.com/300/E2E8F0/64748B?text=${goldImage.species || 'Image'}`;
 
     return (
         <View style={[styles.card, { backgroundColor: themeColors.card, borderColor: themeColors.border }]}>

--- a/frontend/app/components/researcher/GoldImageCard.tsx
+++ b/frontend/app/components/researcher/GoldImageCard.tsx
@@ -32,7 +32,8 @@ export default function GoldImageCard({ goldImage, onDelete }: Props) {
     return (
         <View style={[styles.card, { backgroundColor: themeColors.card, borderColor: themeColors.border }]}>
             {/* Image Thumbnail */}
-            <View style={styles.imageContainer}>
+            {/* pointerEvents on View, not Image — Image doesn't accept this prop */}
+            <View style={styles.imageContainer} pointerEvents="none">
                 <Image
                     source={{ uri: finalUri }}
                     style={styles.thumbnail}
@@ -55,9 +56,8 @@ export default function GoldImageCard({ goldImage, onDelete }: Props) {
             {/* Delete Button */}
             <TouchableOpacity
                 style={styles.deleteButton}
-                onPress={(e) => {
-                    onDelete();
-                }}
+                onPress={onDelete}
+                activeOpacity={0.6}
             >
                 <Ionicons name="trash-outline" size={22} color="#EF4444" />
             </TouchableOpacity>

--- a/frontend/app/screens/researcher/AddGoldImageScreen.tsx
+++ b/frontend/app/screens/researcher/AddGoldImageScreen.tsx
@@ -1,7 +1,7 @@
 // researcher screen for adding gold images
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import {
-    Alert,
+    ActivityIndicator,
     ScrollView,
     StyleSheet,
     Text,
@@ -20,6 +20,8 @@ import { API_ENDPOINTS } from '../../api/apiEndpoints';
 import { useQueryClient } from '@tanstack/react-query';
 import MultiSelect from '../../components/ui/MultiSelect';
 
+type UrlValidationState = 'idle' | 'checking' | 'valid' | 'invalid';
+
 export default function AddGoldImageScreen({ navigation }: any) {
     const queryClient = useQueryClient();
     const [uploadType, setUploadType] = useState<"url" | "file">("file");
@@ -29,12 +31,19 @@ export default function AddGoldImageScreen({ navigation }: any) {
     const [species, setSpecies] = useState("");
     const [difficultyLevel, setDifficultyLevel] = useState("MEDIUM");
     const [loading, setLoading] = useState(false);
-    const [statusMessage, setStatusMessage] = useState<{ type: 'error' | 'success', text: string } | null>(null);
+    const [statusMessage, setStatusMessage] = useState<{ type: 'error' | 'success'; text: string } | null>(null);
     const { theme } = useThemeStore();
     const themeColors = Colors[theme as keyof typeof Colors];
 
     const [availableSpecies, setAvailableSpecies] = useState<{ id: string; label: string }[]>([]);
     const [optionsLoading, setOptionsLoading] = useState(false);
+
+    // URL real-time validation state
+    const [urlValidation, setUrlValidation] = useState<UrlValidationState>('idle');
+    const [urlError, setUrlError] = useState<string>('');
+    const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const isDark = theme === 'dark';
 
     useEffect(() => {
         const fetchOptions = async () => {
@@ -43,10 +52,10 @@ export default function AddGoldImageScreen({ navigation }: any) {
                 const speciesRes = await apiFetch('/api/v1/metadata/species');
                 if (speciesRes.ok) {
                     const sps = await speciesRes.json();
-                    setAvailableSpecies(sps.map((s: any) => ({ 
-                        id: String(s.id), 
+                    setAvailableSpecies(sps.map((s: any) => ({
+                        id: String(s.id),
                         label: String(s.label),
-                        searchTerms: String(s.searchTerms || "") 
+                        searchTerms: String(s.searchTerms || "")
                     })));
                 }
             } catch (error) {
@@ -61,18 +70,6 @@ export default function AddGoldImageScreen({ navigation }: any) {
     // For demo purposes, using taskId = 1. In production, this would come from navigation params
     const taskId = 1;
 
-    const pickImage = async () => {
-        let result = await ImagePicker.launchImageLibraryAsync({
-            mediaTypes: ImagePicker.MediaTypeOptions.Images,
-            allowsEditing: true,
-            quality: 1,
-        });
-
-        if (!result.canceled) {
-            setImageFile(result.assets[0]);
-        }
-    };
-
     const validateImageUrl = async (url: string): Promise<string | null> => {
         try {
             // Try HEAD first (cheaper), fall back to GET if server doesn't allow HEAD
@@ -85,45 +82,98 @@ export default function AddGoldImageScreen({ navigation }: any) {
             }
             const contentType = response.headers.get('content-type') || '';
             if (!contentType.toLowerCase().startsWith('image/')) {
-                return `The URL does not point to an image (Content-Type: "${contentType}"). Only image links are accepted.`;
+                return `Not an image (Content-Type: "${contentType}"). Only image links are accepted.`;
             }
             return null; // valid
         } catch {
-            return 'Could not reach the URL. Make sure it is publicly accessible and try again.';
+            return 'Could not reach the URL. Make sure it is publicly accessible.';
+        }
+    };
+
+    // Debounced real-time URL validation — fires 800ms after the user stops typing
+    const handleUrlChange = useCallback((text: string) => {
+        setImageUrl(text);
+
+        if (debounceTimer.current) clearTimeout(debounceTimer.current);
+
+        if (!text.trim()) {
+            setUrlValidation('idle');
+            setUrlError('');
+            return;
+        }
+
+        // Basic format check before even hitting the network
+        try {
+            new URL(text);
+        } catch {
+            setUrlValidation('invalid');
+            setUrlError('Enter a valid URL (e.g. https://example.com/image.jpg)');
+            return;
+        }
+
+        setUrlValidation('checking');
+        setUrlError('');
+
+        debounceTimer.current = setTimeout(async () => {
+            const err = await validateImageUrl(text);
+            if (err) {
+                setUrlValidation('invalid');
+                setUrlError(err);
+            } else {
+                setUrlValidation('valid');
+                setUrlError('');
+            }
+        }, 800);
+    }, []);
+
+    const pickImage = async () => {
+        let result = await ImagePicker.launchImageLibraryAsync({
+            mediaTypes: ImagePicker.MediaTypeOptions.Images,
+            allowsEditing: true,
+            quality: 1,
+        });
+        if (!result.canceled) {
+            setImageFile(result.assets[0]);
         }
     };
 
     const handleSubmit = async () => {
-        setStatusMessage(null); // Clear previous status
-        
-        // Validation
+        setStatusMessage(null);
+
         if (!taskId) {
-            setStatusMessage({ type: 'error', text: "Validation Error: Task ID is required" });
+            setStatusMessage({ type: 'error', text: "Task ID is required" });
             return;
         }
         if (uploadType === "url" && !imageUrl) {
-            setStatusMessage({ type: 'error', text: "Validation Error: Image URL is required" });
+            setStatusMessage({ type: 'error', text: "Image URL is required" });
+            return;
+        }
+        if (uploadType === "url" && urlValidation === 'invalid') {
+            setStatusMessage({ type: 'error', text: urlError || "The image URL is not valid." });
             return;
         }
         if (uploadType === "file" && !imageFile) {
-            setStatusMessage({ type: 'error', text: "Validation Error: An image file is required" });
+            setStatusMessage({ type: 'error', text: "An image file is required" });
             return;
         }
         if (!species) {
-            setStatusMessage({ type: 'error', text: "Validation Error: Species is required" });
+            setStatusMessage({ type: 'error', text: "Species is required" });
             return;
         }
 
-        // Validate URL points to a real image before sending to backend
-        if (uploadType === "url") {
+        // If URL hasn't been verified yet (still checking or idle), run validation now
+        if (uploadType === "url" && urlValidation !== 'valid') {
             setLoading(true);
-            setStatusMessage({ type: 'error', text: 'Validating image URL...' });
-            const urlError = await validateImageUrl(imageUrl);
+            setStatusMessage({ type: 'error', text: 'Validating image URL…' });
+            const err = await validateImageUrl(imageUrl);
             setLoading(false);
-            if (urlError) {
-                setStatusMessage({ type: 'error', text: urlError });
+            if (err) {
+                setUrlValidation('invalid');
+                setUrlError(err);
+                setStatusMessage({ type: 'error', text: err });
                 return;
             }
+            setUrlValidation('valid');
             setStatusMessage(null);
         }
 
@@ -134,8 +184,6 @@ export default function AddGoldImageScreen({ navigation }: any) {
 
         if (uploadType === "file" && imageFile) {
             if (Platform.OS === 'web') {
-                // On Web, imageFile.uri is a blob URL. We need to fetch it to get a Blob,
-                // or use imageFile.file if it exists in newer expo-image-picker versions.
                 if (imageFile.file) {
                     formData.append("file", imageFile.file);
                 } else {
@@ -148,12 +196,7 @@ export default function AddGoldImageScreen({ navigation }: any) {
                 const filename = imageFile.fileName || localUri.split('/').pop() || 'image.jpg';
                 const match = /\.(\w+)$/.exec(filename);
                 const type = match ? `image/${match[1]}` : `image`;
-
-                formData.append("file", {
-                    uri: localUri,
-                    name: filename,
-                    type,
-                } as any);
+                formData.append("file", { uri: localUri, name: filename, type } as any);
             }
         } else if (uploadType === "url") {
             formData.append("imageUrl", imageUrl);
@@ -168,34 +211,40 @@ export default function AddGoldImageScreen({ navigation }: any) {
 
             if (!res.ok) {
                 const errorText = await res.text();
-                throw new Error(`HTTP error! status: ${res.status} - ${errorText}`);
+                throw new Error(`HTTP ${res.status} – ${errorText}`);
             }
 
-            const data = await res.json();
-            console.log("AddGoldImage response:", data);
+            await res.json();
 
-            // Invalidate the cache for gold images so the list updates
             queryClient.invalidateQueries({ queryKey: ['researcher', 'goldImages'] });
 
-            setStatusMessage({ type: 'success', text: "Gold image created successfully! Redirecting..." });
-            
-            // Wait 1.5 seconds for the user to read the success message before navigating away
-            setTimeout(() => {
-                navigation.navigate("AdminDashboard");
-            }, 1500);
+            setStatusMessage({ type: 'success', text: "Gold image created successfully! Redirecting…" });
 
+            // Navigate to the Gold Images list after a brief success message
+            setTimeout(() => {
+                navigation.navigate("GoldImagesManagement");
+            }, 1500);
         } catch (err: any) {
             console.error("Error creating gold image:", err);
-            const errMsg = "Failed to create gold image: " + (err.message || "Check fields.");
-            setStatusMessage({ type: 'error', text: errMsg });
+            setStatusMessage({ type: 'error', text: "Failed to create gold image: " + (err.message || "Check fields.") });
         } finally {
             setLoading(false);
         }
     };
 
-    const handleCancel = () => {
-        navigation.goBack();
-    };
+    // Derived border color for URL input
+    const urlBorderColor =
+        urlValidation === 'valid' ? '#10B981' :
+        urlValidation === 'invalid' ? '#EF4444' :
+        themeColors.border;
+
+    const urlBgColor =
+        urlValidation === 'valid' ? (isDark ? 'rgba(16,185,129,0.1)' : '#F0FDF4') :
+        urlValidation === 'invalid' ? (isDark ? 'rgba(239,68,68,0.1)' : '#FEF2F2') :
+        themeColors.card;
+
+    const cardBg = isDark ? 'rgba(255,255,255,0.05)' : '#FFFFFF';
+    const cardBorder = isDark ? 'rgba(255,255,255,0.08)' : '#E5E7EB';
 
     return (
         <ScreenHeaderLayout
@@ -205,27 +254,33 @@ export default function AddGoldImageScreen({ navigation }: any) {
             rightTitle="Gold Images"
             onRightPress={() => navigation.navigate("GoldImagesManagement")}
         >
-            <ScrollView contentContainerStyle={[styles.container, { backgroundColor: themeColors.background }]} showsVerticalScrollIndicator={false}>
-                {/* Upload Mode Selection */}
-                <View style={styles.toggleSection}>
-                    <Text style={[styles.sectionTitle, { color: themeColors.text }]}>Upload Type</Text>
+            <ScrollView
+                contentContainerStyle={[styles.container, { backgroundColor: themeColors.background }]}
+                showsVerticalScrollIndicator={false}
+            >
+                {/* ── Upload Type ── */}
+                <View style={[styles.card, { backgroundColor: cardBg, borderColor: cardBorder }]}>
+                    <Text style={[styles.cardLabel, { color: themeColors.textSecondary }]}>UPLOAD TYPE</Text>
+                    <Text style={[styles.sectionTitle, { color: themeColors.text }]}>How would you like to add the image?</Text>
                     <View style={styles.toggleButtons}>
                         {(['file', 'url'] as const).map((type) => (
                             <TouchableOpacity
                                 key={type}
                                 style={[
                                     styles.toggleButton,
-                                    { backgroundColor: themeColors.card, borderColor: themeColors.border },
+                                    { borderColor: cardBorder, backgroundColor: themeColors.background },
                                     uploadType === type && styles.toggleButtonActive,
                                 ]}
-                                onPress={() => setUploadType(type)}
+                                onPress={() => {
+                                    setUploadType(type);
+                                    setUrlValidation('idle');
+                                    setUrlError('');
+                                }}
                             >
-                                <Text
-                                    style={[
-                                        styles.toggleText,
-                                        uploadType === type && styles.toggleTextActive,
-                                    ]}
-                                >
+                                <Text style={[styles.toggleIcon]}>
+                                    {type === 'file' ? '📁' : '🔗'}
+                                </Text>
+                                <Text style={[styles.toggleText, uploadType === type && styles.toggleTextActive]}>
                                     {type === 'file' ? 'Upload File' : 'Image URL'}
                                 </Text>
                             </TouchableOpacity>
@@ -233,121 +288,168 @@ export default function AddGoldImageScreen({ navigation }: any) {
                     </View>
                 </View>
 
-                {/* Upload Section */}
-                <View style={styles.uploadSection}>
+                {/* ── Image Input ── */}
+                <View style={[styles.card, { backgroundColor: cardBg, borderColor: cardBorder }]}>
+                    <Text style={[styles.cardLabel, { color: themeColors.textSecondary }]}>IMAGE SOURCE</Text>
                     {uploadType === "url" ? (
-                        <TextInput
-                            style={[styles.input, { backgroundColor: themeColors.background, borderColor: themeColors.border, color: themeColors.text }]}
-                            value={imageUrl}
-                            onChangeText={setImageUrl}
-                            placeholder="Enter image URL"
-                            placeholderTextColor={themeColors.textSecondary}
-                        />
+                        <View>
+                            <Text style={[styles.sectionTitle, { color: themeColors.text }]}>Image URL</Text>
+                            <View style={styles.urlInputRow}>
+                                <TextInput
+                                    style={[
+                                        styles.input,
+                                        styles.urlInput,
+                                        {
+                                            backgroundColor: urlBgColor,
+                                            borderColor: urlBorderColor,
+                                            color: themeColors.text,
+                                        },
+                                    ]}
+                                    value={imageUrl}
+                                    onChangeText={handleUrlChange}
+                                    placeholder="https://example.com/image.jpg"
+                                    placeholderTextColor={themeColors.textSecondary}
+                                    autoCapitalize="none"
+                                    keyboardType="url"
+                                />
+                                <View style={styles.urlIndicator}>
+                                    {urlValidation === 'checking' && (
+                                        <ActivityIndicator size="small" color="#3B82F6" />
+                                    )}
+                                    {urlValidation === 'valid' && (
+                                        <Text style={styles.validIcon}>✓</Text>
+                                    )}
+                                    {urlValidation === 'invalid' && (
+                                        <Text style={styles.invalidIcon}>✗</Text>
+                                    )}
+                                </View>
+                            </View>
+                            {urlValidation === 'invalid' && urlError ? (
+                                <Text style={styles.urlErrorText}>{urlError}</Text>
+                            ) : null}
+                            {urlValidation === 'valid' ? (
+                                <Text style={styles.urlSuccessText}>✓ Valid image URL</Text>
+                            ) : null}
+                        </View>
                     ) : (
-                        <View style={styles.filePickerContainer}>
-                            <TouchableOpacity style={styles.pickButton} onPress={pickImage}>
-                                <Text style={styles.pickButtonText}>Select Image From Device</Text>
+                        <View>
+                            <Text style={[styles.sectionTitle, { color: themeColors.text }]}>Select from Device</Text>
+                            <TouchableOpacity
+                                style={[styles.pickButton, { backgroundColor: themeColors.background, borderColor: cardBorder }]}
+                                onPress={pickImage}
+                            >
+                                <Text style={styles.pickButtonIcon}>📷</Text>
+                                <Text style={[styles.pickButtonText, { color: themeColors.text }]}>
+                                    {imageFile ? 'Change Image' : 'Browse & Select Image'}
+                                </Text>
                             </TouchableOpacity>
                             {imageFile && (
-                                <RNImage
-                                    source={{ uri: imageFile.uri }}
-                                    style={styles.previewImage}
-                                />
+                                <View style={styles.previewContainer}>
+                                    <RNImage source={{ uri: imageFile.uri }} style={styles.previewImage} />
+                                    <View style={styles.previewBadge}>
+                                        <Text style={styles.previewBadgeText}>✓ Ready</Text>
+                                    </View>
+                                </View>
                             )}
                         </View>
                     )}
                 </View>
 
-                {/* Is Valid Requested Species? Toggle */}
-                <View style={styles.toggleSection}>
-                    <Text style={[styles.sectionTitle, { color: themeColors.text }]}>Is this picture actually the requested species?</Text>
-                    <View style={styles.toggleButtons}>
-                        {(['YES', 'NO'] as const).map((ans) => (
-                            <TouchableOpacity
-                                key={ans}
-                                style={[
-                                    styles.toggleButton,
-                                    { backgroundColor: themeColors.card, borderColor: themeColors.border },
-                                    correctAnswer === ans && styles.toggleButtonActive,
-                                ]}
-                                onPress={() => setCorrectAnswer(ans)}
-                            >
-                                <Text
-                                    style={[
-                                        styles.toggleText,
-                                        correctAnswer === ans && styles.toggleTextActive,
-                                    ]}
-                                >
-                                    {ans}
-                                </Text>
-                            </TouchableOpacity>
-                        ))}
-                    </View>
-                </View>
-
-                {/* Taxonomy Fields */}
-                <View style={styles.taxonomySection}>
+                {/* ── Species ── */}
+                <View style={[styles.card, { backgroundColor: cardBg, borderColor: cardBorder, zIndex: 10 }]}>
+                    <Text style={[styles.cardLabel, { color: themeColors.textSecondary }]}>TAXONOMY</Text>
                     <Text style={[styles.sectionTitle, { color: themeColors.text }]}>Species</Text>
-                    <Text style={{ color: themeColors.textSecondary, marginBottom: 8, fontSize: 13 }}>
+                    <Text style={[styles.sectionHint, { color: themeColors.textSecondary }]}>
                         Search and select the relevant species from the taxonomy.
                     </Text>
                     <MultiSelect
                         options={availableSpecies}
                         selectedIds={species ? [species] : []}
                         onToggle={(id) => {
-                            if (species === id) {
-                                setSpecies(""); // deselect
-                            } else {
-                                setSpecies(id as string);
-                            }
+                            setSpecies(species === id ? "" : id as string);
                         }}
-                        placeholder="Search for species..."
+                        placeholder="Search for species…"
                         loading={optionsLoading}
                         emptyOnNoSearch={true}
                     />
                 </View>
 
-                {/* Difficulty Level */}
-                <View style={styles.difficultySection}>
-                    <Text style={[styles.sectionTitle, { color: themeColors.text }]}>Difficulty Level</Text>
+                {/* ── Correct Answer ── */}
+                <View style={[styles.card, { backgroundColor: cardBg, borderColor: cardBorder }]}>
+                    <Text style={[styles.cardLabel, { color: themeColors.textSecondary }]}>CLASSIFICATION</Text>
+                    <Text style={[styles.sectionTitle, { color: themeColors.text }]}>
+                        Is this picture actually the requested species?
+                    </Text>
                     <View style={styles.toggleButtons}>
-                        {["EASY", "MEDIUM", "HARD"].map((level) => (
+                        {(['YES', 'NO'] as const).map((ans) => (
                             <TouchableOpacity
-                                key={level}
+                                key={ans}
                                 style={[
                                     styles.toggleButton,
-                                    { backgroundColor: themeColors.card, borderColor: themeColors.border },
-                                    difficultyLevel === level && styles.toggleButtonActive,
+                                    { borderColor: cardBorder, backgroundColor: themeColors.background },
+                                    correctAnswer === ans && (ans === 'YES' ? styles.toggleButtonYes : styles.toggleButtonNo),
                                 ]}
-                                onPress={() => setDifficultyLevel(level)}
+                                onPress={() => setCorrectAnswer(ans)}
                             >
-                                <Text
-                                    style={[
-                                        styles.toggleText,
-                                        difficultyLevel === level && styles.toggleTextActive,
-                                    ]}
-                                >
-                                    {level}
+                                <Text style={styles.toggleIcon}>{ans === 'YES' ? '✓' : '✗'}</Text>
+                                <Text style={[
+                                    styles.toggleText,
+                                    correctAnswer === ans && styles.toggleTextActive,
+                                ]}>
+                                    {ans === 'YES' ? 'Yes' : 'No'}
                                 </Text>
                             </TouchableOpacity>
                         ))}
                     </View>
                 </View>
 
-                {/* Status Message Display */}
+                {/* ── Difficulty ── */}
+                <View style={[styles.card, { backgroundColor: cardBg, borderColor: cardBorder }]}>
+                    <Text style={[styles.cardLabel, { color: themeColors.textSecondary }]}>DIFFICULTY</Text>
+                    <Text style={[styles.sectionTitle, { color: themeColors.text }]}>Difficulty Level</Text>
+                    <View style={styles.toggleButtons}>
+                        {(["EASY", "MEDIUM", "HARD"] as const).map((level) => (
+                            <TouchableOpacity
+                                key={level}
+                                style={[
+                                    styles.toggleButton,
+                                    { borderColor: cardBorder, backgroundColor: themeColors.background },
+                                    difficultyLevel === level && difficultyStyles[level],
+                                ]}
+                                onPress={() => setDifficultyLevel(level)}
+                            >
+                                <Text style={styles.toggleIcon}>{level === 'EASY' ? '🟢' : level === 'MEDIUM' ? '🟡' : '🔴'}</Text>
+                                <Text style={[
+                                    styles.toggleText,
+                                    difficultyLevel === level && styles.toggleTextActive,
+                                ]}>
+                                    {level.charAt(0) + level.slice(1).toLowerCase()}
+                                </Text>
+                            </TouchableOpacity>
+                        ))}
+                    </View>
+                </View>
+
+                {/* ── Status Message ── */}
                 {statusMessage && (
-                    <View style={[styles.statusContainer, { backgroundColor: statusMessage.type === 'error' ? '#FEE2E2' : '#DCFCE7' }]}>
-                        <Text style={[styles.statusText, { color: statusMessage.type === 'error' ? '#B91C1C' : '#15803D' }]}>
+                    <View style={[
+                        styles.statusContainer,
+                        { backgroundColor: statusMessage.type === 'error' ? '#FEE2E2' : '#DCFCE7' },
+                    ]}>
+                        <Text style={[
+                            styles.statusText,
+                            { color: statusMessage.type === 'error' ? '#B91C1C' : '#15803D' },
+                        ]}>
                             {statusMessage.text}
                         </Text>
                     </View>
                 )}
 
-                {/* Action Buttons */}
+                {/* ── Action Buttons ── */}
                 <View style={styles.actionButtons}>
                     <TouchableOpacity
                         style={styles.cancelButton}
-                        onPress={handleCancel}
+                        onPress={() => navigation.goBack()}
                         disabled={loading}
                     >
                         <Text style={styles.cancelButtonText}>✕</Text>
@@ -358,9 +460,10 @@ export default function AddGoldImageScreen({ navigation }: any) {
                         onPress={handleSubmit}
                         disabled={loading}
                     >
-                        <Text style={styles.submitButtonText}>
-                            {loading ? "..." : "➔"}
-                        </Text>
+                        {loading
+                            ? <ActivityIndicator size="small" color="#fff" />
+                            : <Text style={styles.submitButtonText}>➔</Text>
+                        }
                     </TouchableOpacity>
                 </View>
             </ScrollView>
@@ -368,32 +471,75 @@ export default function AddGoldImageScreen({ navigation }: any) {
     );
 }
 
+const difficultyStyles: Record<string, object> = {
+    EASY:   { backgroundColor: '#10B981', borderColor: '#10B981' },
+    MEDIUM: { backgroundColor: '#F59E0B', borderColor: '#F59E0B' },
+    HARD:   { backgroundColor: '#EF4444', borderColor: '#EF4444' },
+};
+
 const styles = StyleSheet.create({
     container: {
         padding: 16,
+        gap: 16,
     },
-    toggleSection: {
-        marginBottom: 20,
+    // ── Card ──
+    card: {
+        borderRadius: 14,
+        borderWidth: 1,
+        padding: 18,
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 2 },
+        shadowOpacity: 0.06,
+        shadowRadius: 6,
+        elevation: 2,
+    },
+    cardLabel: {
+        fontSize: 11,
+        fontWeight: '700',
+        letterSpacing: 1.2,
+        marginBottom: 4,
+        textTransform: 'uppercase',
     },
     sectionTitle: {
-        fontSize: 14,
-        fontWeight: "600",
-        marginBottom: 12,
+        fontSize: 15,
+        fontWeight: '700',
+        marginBottom: 14,
     },
+    sectionHint: {
+        fontSize: 13,
+        marginBottom: 10,
+        marginTop: -8,
+    },
+    // ── Toggle Pills ──
     toggleButtons: {
         flexDirection: "row",
-        gap: 12,
+        gap: 10,
     },
     toggleButton: {
         flex: 1,
-        paddingVertical: 12,
-        borderRadius: 8,
-        alignItems: "center",
-        borderWidth: 1,
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 6,
+        paddingVertical: 11,
+        paddingHorizontal: 8,
+        borderRadius: 10,
+        borderWidth: 1.5,
     },
     toggleButtonActive: {
         backgroundColor: "#3B82F6",
         borderColor: "#3B82F6",
+    },
+    toggleButtonYes: {
+        backgroundColor: "#10B981",
+        borderColor: "#10B981",
+    },
+    toggleButtonNo: {
+        backgroundColor: "#EF4444",
+        borderColor: "#EF4444",
+    },
+    toggleIcon: {
+        fontSize: 15,
     },
     toggleText: {
         fontSize: 14,
@@ -403,47 +549,108 @@ const styles = StyleSheet.create({
     toggleTextActive: {
         color: "#fff",
     },
-    uploadSection: {
-        marginBottom: 24,
+    // ── URL Input ──
+    urlInputRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 8,
     },
     input: {
-        borderWidth: 1,
+        borderWidth: 1.5,
         borderRadius: 10,
         padding: 12,
         fontSize: 14,
     },
-    filePickerContainer: {
-        alignItems: "center",
-        gap: 16,
+    urlInput: {
+        flex: 1,
     },
+    urlIndicator: {
+        width: 28,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    validIcon: {
+        fontSize: 20,
+        color: '#10B981',
+        fontWeight: 'bold',
+    },
+    invalidIcon: {
+        fontSize: 20,
+        color: '#EF4444',
+        fontWeight: 'bold',
+    },
+    urlErrorText: {
+        color: '#DC2626',
+        fontSize: 12,
+        marginTop: 6,
+        lineHeight: 16,
+    },
+    urlSuccessText: {
+        color: '#059669',
+        fontSize: 12,
+        marginTop: 6,
+        fontWeight: '600',
+    },
+    // ── File Picker ──
     pickButton: {
-        backgroundColor: "#E5E7EB",
-        padding: 12,
-        borderRadius: 8,
-        width: "100%",
-        alignItems: "center",
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 10,
+        padding: 14,
+        borderRadius: 10,
+        borderWidth: 1.5,
+        borderStyle: 'dashed',
+    },
+    pickButtonIcon: {
+        fontSize: 20,
     },
     pickButtonText: {
-        color: "#374151",
         fontWeight: "600",
+        fontSize: 14,
+    },
+    previewContainer: {
+        alignItems: 'center',
+        marginTop: 14,
+        position: 'relative',
     },
     previewImage: {
         width: 200,
         height: 200,
         borderRadius: 12,
     },
-    taxonomySection: {
-        marginBottom: 24,
-        zIndex: 10,
+    previewBadge: {
+        position: 'absolute',
+        bottom: 8,
+        right: 'auto',
+        backgroundColor: '#10B981',
+        paddingHorizontal: 10,
+        paddingVertical: 4,
+        borderRadius: 20,
     },
-    difficultySection: {
-        marginBottom: 24,
+    previewBadgeText: {
+        color: '#fff',
+        fontWeight: '700',
+        fontSize: 12,
     },
+    // ── Status ──
+    statusContainer: {
+        padding: 14,
+        borderRadius: 10,
+        alignItems: 'center',
+    },
+    statusText: {
+        fontSize: 14,
+        fontWeight: '500',
+        textAlign: 'center',
+    },
+    // ── Action Buttons ──
     actionButtons: {
         flexDirection: "row",
         justifyContent: "center",
         gap: 24,
-        marginTop: 12,
+        marginTop: 4,
+        marginBottom: 8,
     },
     cancelButton: {
         width: 60,
@@ -452,9 +659,14 @@ const styles = StyleSheet.create({
         backgroundColor: "#EF4444",
         justifyContent: "center",
         alignItems: "center",
+        shadowColor: '#EF4444',
+        shadowOffset: { width: 0, height: 4 },
+        shadowOpacity: 0.3,
+        shadowRadius: 8,
+        elevation: 4,
     },
     cancelButtonText: {
-        fontSize: 28,
+        fontSize: 22,
         color: "#fff",
         fontWeight: "bold",
     },
@@ -465,24 +677,19 @@ const styles = StyleSheet.create({
         backgroundColor: "#3B82F6",
         justifyContent: "center",
         alignItems: "center",
+        shadowColor: '#3B82F6',
+        shadowOffset: { width: 0, height: 4 },
+        shadowOpacity: 0.3,
+        shadowRadius: 8,
+        elevation: 4,
     },
     submitButtonText: {
-        fontSize: 28,
+        fontSize: 26,
         color: "#fff",
         fontWeight: "bold",
     },
     buttonDisabled: {
         backgroundColor: "#94A3B8",
-    },
-    statusContainer: {
-        padding: 12,
-        borderRadius: 8,
-        marginBottom: 16,
-        alignItems: 'center',
-    },
-    statusText: {
-        fontSize: 14,
-        fontWeight: '500',
-        textAlign: 'center',
+        shadowColor: 'transparent',
     },
 });

--- a/frontend/app/screens/researcher/AddGoldImageScreen.tsx
+++ b/frontend/app/screens/researcher/AddGoldImageScreen.tsx
@@ -328,7 +328,19 @@ export default function AddGoldImageScreen({ navigation }: any) {
                                 <Text style={styles.urlErrorText}>{urlError}</Text>
                             ) : null}
                             {urlValidation === 'valid' ? (
-                                <Text style={styles.urlSuccessText}>✓ Valid image URL</Text>
+                                <>
+                                    <Text style={styles.urlSuccessText}>✓ Valid image URL</Text>
+                                    <View style={styles.previewContainer}>
+                                        <RNImage
+                                            source={{ uri: imageUrl }}
+                                            style={styles.previewImage}
+                                            resizeMode="cover"
+                                        />
+                                        <View style={styles.previewBadge}>
+                                            <Text style={styles.previewBadgeText}>✓ Preview</Text>
+                                        </View>
+                                    </View>
+                                </>
                             ) : null}
                         </View>
                     ) : (

--- a/frontend/app/screens/researcher/AddGoldImageScreen.tsx
+++ b/frontend/app/screens/researcher/AddGoldImageScreen.tsx
@@ -73,6 +73,26 @@ export default function AddGoldImageScreen({ navigation }: any) {
         }
     };
 
+    const validateImageUrl = async (url: string): Promise<string | null> => {
+        try {
+            // Try HEAD first (cheaper), fall back to GET if server doesn't allow HEAD
+            let response = await fetch(url, { method: 'HEAD' });
+            if (response.status === 405) {
+                response = await fetch(url, { method: 'GET' });
+            }
+            if (!response.ok) {
+                return `URL returned HTTP ${response.status}. Check the link is correct and publicly accessible.`;
+            }
+            const contentType = response.headers.get('content-type') || '';
+            if (!contentType.toLowerCase().startsWith('image/')) {
+                return `The URL does not point to an image (Content-Type: "${contentType}"). Only image links are accepted.`;
+            }
+            return null; // valid
+        } catch {
+            return 'Could not reach the URL. Make sure it is publicly accessible and try again.';
+        }
+    };
+
     const handleSubmit = async () => {
         setStatusMessage(null); // Clear previous status
         
@@ -92,6 +112,19 @@ export default function AddGoldImageScreen({ navigation }: any) {
         if (!species) {
             setStatusMessage({ type: 'error', text: "Validation Error: Species is required" });
             return;
+        }
+
+        // Validate URL points to a real image before sending to backend
+        if (uploadType === "url") {
+            setLoading(true);
+            setStatusMessage({ type: 'error', text: 'Validating image URL...' });
+            const urlError = await validateImageUrl(imageUrl);
+            setLoading(false);
+            if (urlError) {
+                setStatusMessage({ type: 'error', text: urlError });
+                return;
+            }
+            setStatusMessage(null);
         }
 
         const formData = new FormData();

--- a/frontend/app/screens/researcher/GoldImagesManagementScreen.tsx
+++ b/frontend/app/screens/researcher/GoldImagesManagementScreen.tsx
@@ -1,6 +1,14 @@
 // researcher screen for managing gold images
-import React from "react";
-import { Alert, FlatList, StyleSheet, Text, View } from "react-native";
+import React, { useState } from "react";
+import {
+    FlatList,
+    Modal,
+    StyleSheet,
+    Text,
+    TouchableOpacity,
+    TouchableWithoutFeedback,
+    View,
+} from "react-native";
 import { useQueryClient } from '@tanstack/react-query';
 import { Colors } from '../../../constants/theme';
 import { apiFetch } from "../../api/apiFetch";
@@ -25,36 +33,31 @@ export default function GoldImagesManagementScreen({ navigation }: any) {
     const queryClient = useQueryClient();
     const { data: goldImages = [], isLoading: loading } = useGoldImages();
 
+    // ID of the gold image pending deletion; null means modal is closed
+    const [pendingDeleteId, setPendingDeleteId] = useState<number | null>(null);
+
     const handleDelete = (goldImageId: number) => {
-        Alert.alert(
-            "Delete Gold Image",
-            "Are you sure you want to delete this gold image?",
-            [
-                { text: "Cancel", style: "cancel" },
-                {
-                    text: "Delete",
-                    style: "destructive",
-                    onPress: async () => {
-                        try {
-                            const response = await apiFetch(
-                                API_ENDPOINTS.researcher.GOLD_IMAGE_DETAILS(goldImageId),
-                                { method: "DELETE" }
-                            );
-                            if (!response.ok) {
-                                const body = await response.json().catch(() => ({}));
-                                throw new Error((body as any).message ?? `Server error ${response.status}`);
-                            }
-                            // Invalidate cache so the list re-fetches with the item removed
-                            queryClient.invalidateQueries({ queryKey: ['researcher', 'goldImages'] });
-                            Alert.alert("Success", "Gold image deleted successfully");
-                        } catch (err: any) {
-                            console.error("Delete error:", err);
-                            Alert.alert("Error", err?.message ?? "Failed to delete gold image");
-                        }
-                    },
-                },
-            ]
-        );
+        setPendingDeleteId(goldImageId);
+    };
+
+    const confirmDelete = async () => {
+        if (pendingDeleteId === null) return;
+        const id = pendingDeleteId;
+        setPendingDeleteId(null);
+
+        try {
+            const response = await apiFetch(
+                API_ENDPOINTS.researcher.GOLD_IMAGE_DETAILS(id),
+                { method: "DELETE" }
+            );
+            if (!response.ok) {
+                const body = await response.json().catch(() => ({}));
+                throw new Error((body as any).message ?? `Server error ${response.status}`);
+            }
+            queryClient.invalidateQueries({ queryKey: ['researcher', 'goldImages'] });
+        } catch (err: any) {
+            console.error("Delete error:", err);
+        }
     };
 
     return (
@@ -89,6 +92,38 @@ export default function GoldImagesManagementScreen({ navigation }: any) {
                     )}
                 />
             )}
+
+            {/* Delete Confirmation Modal */}
+            <Modal visible={pendingDeleteId !== null} animationType="fade" transparent>
+                <TouchableWithoutFeedback onPress={() => setPendingDeleteId(null)}>
+                    <View style={styles.modalOverlay}>
+                        <TouchableWithoutFeedback onPress={() => {}}>
+                            <View style={[styles.modalContent, { backgroundColor: themeColors.card }]}>
+                                <Text style={[styles.modalTitle, { color: themeColors.text }]}>
+                                    Delete Gold Image
+                                </Text>
+                                <Text style={[styles.modalMessage, { color: themeColors.textSecondary }]}>
+                                    Are you sure you want to delete this gold image? This action cannot be undone.
+                                </Text>
+                                <View style={styles.modalActions}>
+                                    <TouchableOpacity
+                                        style={[styles.actionBtn, styles.cancelBtn]}
+                                        onPress={() => setPendingDeleteId(null)}
+                                    >
+                                        <Text style={styles.cancelText}>Cancel</Text>
+                                    </TouchableOpacity>
+                                    <TouchableOpacity
+                                        style={[styles.actionBtn, styles.deleteBtn]}
+                                        onPress={confirmDelete}
+                                    >
+                                        <Text style={styles.deleteText}>Delete</Text>
+                                    </TouchableOpacity>
+                                </View>
+                            </View>
+                        </TouchableWithoutFeedback>
+                    </View>
+                </TouchableWithoutFeedback>
+            </Modal>
         </ScreenHeaderLayout>
     );
 }
@@ -102,11 +137,61 @@ const styles = StyleSheet.create({
     emptyText: {
         fontSize: 16,
         fontWeight: "600",
-        color: "#6B7280",
     },
     emptySubtext: {
         fontSize: 14,
-        color: "#9CA3AF",
         marginTop: 8,
+    },
+
+    // Modal
+    modalOverlay: {
+        flex: 1,
+        backgroundColor: 'rgba(0,0,0,0.5)',
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    modalContent: {
+        width: 320,
+        borderRadius: 12,
+        padding: 24,
+        alignItems: 'center',
+    },
+    modalTitle: {
+        fontSize: 18,
+        fontWeight: 'bold',
+        marginBottom: 10,
+        textAlign: 'center',
+    },
+    modalMessage: {
+        fontSize: 14,
+        textAlign: 'center',
+        marginBottom: 24,
+        lineHeight: 20,
+    },
+    modalActions: {
+        flexDirection: 'row',
+        gap: 12,
+        width: '100%',
+        justifyContent: 'center',
+    },
+    actionBtn: {
+        flex: 1,
+        paddingVertical: 12,
+        borderRadius: 8,
+        alignItems: 'center',
+    },
+    cancelBtn: {
+        backgroundColor: '#F1F5F9',
+    },
+    cancelText: {
+        color: '#374151',
+        fontWeight: '600',
+    },
+    deleteBtn: {
+        backgroundColor: '#EF4444',
+    },
+    deleteText: {
+        color: '#fff',
+        fontWeight: '600',
     },
 });

--- a/frontend/app/screens/researcher/GoldImagesManagementScreen.tsx
+++ b/frontend/app/screens/researcher/GoldImagesManagementScreen.tsx
@@ -1,6 +1,7 @@
 // researcher screen for managing gold images
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { Alert, FlatList, StyleSheet, Text, View } from "react-native";
+import { useQueryClient } from '@tanstack/react-query';
 import { Colors } from '../../../constants/theme';
 import { apiFetch } from "../../api/apiFetch";
 import GoldImageCard from "../../components/researcher/GoldImageCard";
@@ -21,7 +22,8 @@ type GoldImageResponse = {
 export default function GoldImagesManagementScreen({ navigation }: any) {
     const { theme } = useThemeStore();
     const themeColors = Colors[theme as keyof typeof Colors];
-    const { data: goldImages = [], isLoading: loading, refetch: fetchGoldImages } = useGoldImages();
+    const queryClient = useQueryClient();
+    const { data: goldImages = [], isLoading: loading } = useGoldImages();
 
     const handleDelete = (goldImageId: number) => {
         Alert.alert(
@@ -34,15 +36,20 @@ export default function GoldImagesManagementScreen({ navigation }: any) {
                     style: "destructive",
                     onPress: async () => {
                         try {
-                            await apiFetch(API_ENDPOINTS.researcher.GOLD_IMAGE_DETAILS(goldImageId), {
-                                method: "DELETE",
-                            });
-                            // Refresh the list
-                            fetchGoldImages();
+                            const response = await apiFetch(
+                                API_ENDPOINTS.researcher.GOLD_IMAGE_DETAILS(goldImageId),
+                                { method: "DELETE" }
+                            );
+                            if (!response.ok) {
+                                const body = await response.json().catch(() => ({}));
+                                throw new Error((body as any).message ?? `Server error ${response.status}`);
+                            }
+                            // Invalidate cache so the list re-fetches with the item removed
+                            queryClient.invalidateQueries({ queryKey: ['researcher', 'goldImages'] });
                             Alert.alert("Success", "Gold image deleted successfully");
-                        } catch (err) {
+                        } catch (err: any) {
                             console.error("Delete error:", err);
-                            Alert.alert("Error", "Failed to delete gold image");
+                            Alert.alert("Error", err?.message ?? "Failed to delete gold image");
                         }
                     },
                 },

--- a/frontend/app/screens/researcher/UsersManagementScreen.tsx
+++ b/frontend/app/screens/researcher/UsersManagementScreen.tsx
@@ -101,7 +101,7 @@ export default function UsersManagementScreen() {
             <View style={[webStyles.tableHeader, { borderBottomColor: themeColors.border }]}>
                 <Text style={[webStyles.headerCell, webStyles.avatarCol, { color: themeColors.textSecondary }]}>Avatar</Text>
                 <TouchableOpacity
-                    style={[webStyles.headerCell, webStyles.usernameCol, { flexDirection: 'row', alignItems: 'center' }]}
+                    style={[webStyles.headerCellBtn, webStyles.usernameCol]}
                     onPress={() => setSortOrder(NEXT_SORT[sortOrder])}
                     accessibilityLabel={`Sort by score, current: ${SORT_LABELS[sortOrder]}`}
                 >


### PR DESCRIPTION
improved UI of add gold image screen & gold images management screen
improve the storing mechanism of uploaded images

Soft-delete on GoldImage (recommended for audit-required projects) ✅ Best fit for SwipeLab
Approach: Add an active (boolean) or deletedAt (timestamp) column to GoldImage. The delete endpoint marks the record inactive instead of removing it. Filter inactive images out of all findAll/getByTask queries.

Pros:

FK constraint is never violated — CredibilityRecord rows remain consistent.
Credibility audit history is 100% intact — critical for a scientific credibility scoring system.
Admin can inspect or even restore accidentally deleted gold images.
Aligns with the domain's scientific integrity requirement.