### PR TITLE
[Frontend] Add Gold Image Guidelines to UI (#223)

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -19,6 +19,7 @@ Architecture: Modular Hexagonal/DDD.
 * Frontend: Removed hardcoded mock task (id=1) from SwipeScreen; implemented 3-state Quick Start UI (active swipe / quick-start task picker / true empty state); aligned all task play entry points with swipeStore (Issue #204).
 * Backend/Frontend: Fixed task duplication bug — added `findPublicTasksExcludingAssignedUser` JPQL query, `getExploreTasksForUser` service method, `POST /tasks/{id}/assign` endpoint with duplicate guard (DuplicateResourceException → HTTP 409), and `useAssignTask` mutation in the frontend (Issue #205).
 * Frontend: Added search bar + sort-by-credibility-score toggle to UsersManagementScreen; updated mock data (Issues #217, #218).
+* Frontend: Added information sections to GoldImagesManagementScreen and AddGoldImageScreen to clarify their purpose for researchers (Issue #223).
 
 ## Current Focus (Active GitHub Issues)
 * Issue #201: Refactor Backend roles to include Researchers and Super Admin.
@@ -26,7 +27,6 @@ Architecture: Modular Hexagonal/DDD.
 * Issue #226: [Frontend] fix recipients list not deleting users.
 * Issue #225: [System] fix refresh token for Researcher.
 * Issue #224: [Frontend] Mobile Vs. Web compatibility enhancement.
-* Issue #223: [Frontend] add a small information in the Gold Images Screen & Add Gold Images.
 * Issue #222: [Frontend] fix TasksManagementScreen UI.
 * Issue #221: [Frontend] adapt to changes of analytics new endpoints.
 * Issue #220: [Backend] improve and add analytics new endpoints.

--- a/frontend/app/screens/researcher/AddGoldImageScreen.tsx
+++ b/frontend/app/screens/researcher/AddGoldImageScreen.tsx
@@ -258,6 +258,18 @@ export default function AddGoldImageScreen({ navigation }: any) {
                 contentContainerStyle={[styles.container, { backgroundColor: themeColors.background }]}
                 showsVerticalScrollIndicator={false}
             >
+                {/* ── Info Banner ── */}
+                <View style={[styles.infoBanner, { backgroundColor: isDark ? 'rgba(59, 130, 246, 0.1)' : '#EFF6FF', borderColor: isDark ? 'rgba(59, 130, 246, 0.2)' : '#BFDBFE' }]}>
+                    <Text style={[styles.infoBannerTitle, { color: isDark ? '#60A5FA' : '#1D4ED8' }]}>
+                        ℹ️ Gold Image Guidelines
+                    </Text>
+                    <Text style={[styles.infoBannerText, { color: themeColors.text }]}>
+                        • Used as a hidden quality control mechanism to calculate user credibility.{"\n"}
+                        • They contain pre-verified labels and are mixed into regular tasks to test accuracy.{"\n"}
+                        • Must look identical to standard experiment photos (e.g., yellow sticky traps) so users cannot tell they are being tested.
+                    </Text>
+                </View>
+
                 {/* ── Upload Type ── */}
                 <View style={[styles.card, { backgroundColor: cardBg, borderColor: cardBorder }]}>
                     <Text style={[styles.cardLabel, { color: themeColors.textSecondary }]}>UPLOAD TYPE</Text>
@@ -493,6 +505,21 @@ const styles = StyleSheet.create({
     container: {
         padding: 16,
         gap: 16,
+    },
+    // ── Info Banner ──
+    infoBanner: {
+        padding: 16,
+        borderRadius: 12,
+        borderWidth: 1,
+    },
+    infoBannerTitle: {
+        fontSize: 16,
+        fontWeight: 'bold',
+        marginBottom: 8,
+    },
+    infoBannerText: {
+        fontSize: 14,
+        lineHeight: 22,
     },
     // ── Card ──
     card: {

--- a/frontend/app/screens/researcher/GoldImagesManagementScreen.tsx
+++ b/frontend/app/screens/researcher/GoldImagesManagementScreen.tsx
@@ -29,6 +29,7 @@ type GoldImageResponse = {
 
 export default function GoldImagesManagementScreen({ navigation }: any) {
     const { theme } = useThemeStore();
+    const isDark = theme === 'dark';
     const themeColors = Colors[theme as keyof typeof Colors];
     const queryClient = useQueryClient();
     const { data: goldImages = [], isLoading: loading } = useGoldImages();
@@ -68,6 +69,17 @@ export default function GoldImagesManagementScreen({ navigation }: any) {
             rightTitle="Add Image"
             onRightPress={() => navigation.navigate("AddGoldImage")}
         >
+            <View style={[styles.infoBanner, { backgroundColor: isDark ? 'rgba(59, 130, 246, 0.1)' : '#EFF6FF', borderColor: isDark ? 'rgba(59, 130, 246, 0.2)' : '#BFDBFE' }]}>
+                <Text style={[styles.infoBannerTitle, { color: isDark ? '#60A5FA' : '#1D4ED8' }]}>
+                    ℹ️ Gold Image Guidelines
+                </Text>
+                <Text style={[styles.infoBannerText, { color: themeColors.text }]}>
+                    • Used as a hidden quality control mechanism to calculate user credibility.{"\n"}
+                    • They contain pre-verified labels and are mixed into regular tasks to test accuracy.{"\n"}
+                    • Must look identical to standard experiment photos (e.g., yellow sticky traps) so users cannot tell they are being tested.
+                </Text>
+            </View>
+
             {loading ? (
                 <View style={[styles.centerContainer, { backgroundColor: themeColors.background }]}>
                     <Text style={{ color: themeColors.text }}>Loading...</Text>
@@ -76,7 +88,7 @@ export default function GoldImagesManagementScreen({ navigation }: any) {
                 <View style={[styles.centerContainer, { backgroundColor: themeColors.background }]}>
                     <Text style={[styles.emptyText, { color: themeColors.textSecondary }]}>No gold images found</Text>
                     <Text style={[styles.emptySubtext, { color: themeColors.textSecondary }]}>
-                        Tap "Add Image" to create your first gold image
+                        Tap &quot;Add Image&quot; to create your first gold image
                     </Text>
                 </View>
             ) : (
@@ -129,6 +141,21 @@ export default function GoldImagesManagementScreen({ navigation }: any) {
 }
 
 const styles = StyleSheet.create({
+    infoBanner: {
+        margin: 16,
+        padding: 16,
+        borderRadius: 12,
+        borderWidth: 1,
+    },
+    infoBannerTitle: {
+        fontSize: 16,
+        fontWeight: 'bold',
+        marginBottom: 8,
+    },
+    infoBannerText: {
+        fontSize: 14,
+        lineHeight: 22,
+    },
     centerContainer: {
         flex: 1,
         justifyContent: "center",


### PR DESCRIPTION
Closes #223.
added an informational guidelines banner to both the `GoldImagesManagementScreen` and `AddGoldImageScreen`. 
<img width="1600" height="724" alt="image" src="https://github.com/user-attachments/assets/c8ad03c5-5c66-4ce4-9716-9fcf833766a2" />
