### PR TITLE
feat: implement HTTP caching mechanism with ETag support, custom Cach…

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -22,10 +22,10 @@ Architecture: Modular Hexagonal/DDD.
 * Frontend: Added information sections to GoldImagesManagementScreen and AddGoldImageScreen to clarify their purpose for researchers (Issue #223).
 * Backend: Implemented analytics overview endpoint + implemented placeholder endpoints — added `GET /api/v1/analytics/overview` (platform-wide time-windowed stats: classifications/images/users/tasks/experiments for today/week/month, 30-day confidence trend, label distribution), added `GET /api/v1/analytics/global-stats`, implemented `getUserPerformanceMetrics` and `getTopPerformers`, added V13 Flyway migration for analytics tables, fixed missing leading `/` on admin endpoints (Issue #220).
 * Frontend: Redesigned AnalyticsScreen with two-tab layout (Overview / Tasks). Overview tab consumes new `/api/v1/analytics/overview` endpoint and renders: TimeWindowCards (Today/Week/Month activity), platform totals, ConfidenceTrendChart (30-day credibility sparkline), LabelDistributionBar (YES/NO/DONT_KNOW/TRASH), and top performers. Tasks tab lists all researcher tasks with expandable per-task analytics panel. Added analyticsTypes.ts, 3 new components, 2 new query hooks, mock routes (Issue #221).
+* Backend: Implemented a two-layer caching strategy combining HTTP caching (`ShallowEtagHeaderFilter` + `CacheControlInterceptor`) and application caching (Caffeine with `@Cacheable` and event-driven eviction via `CacheEvictionListener`) (Issue #154).
 
 ## Current Focus (Active GitHub Issues)
 * Issue #201: Refactor Backend roles to include Researchers and Super Admin.
-* Issue #154: Add version support in API responses for frontend caching.
 * Issue #226: [Frontend] fix recipients list not deleting users.
 * Issue #225: [System] fix refresh token for Researcher.
 * Issue #224: [Frontend] Mobile Vs. Web compatibility enhancement.

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -140,6 +140,16 @@
 
 
 
+		<!-- Application Caching: Spring Cache abstraction + Caffeine in-process cache -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-cache</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.github.ben-manes.caffeine</groupId>
+			<artifactId>caffeine</artifactId>
+		</dependency>
+
 		<!-- Awaitility: polling helper used in integration tests -->
 		<dependency>
 			<groupId>org.awaitility</groupId>

--- a/backend/src/main/java/com/swipelab/analytics/application/AnalyticsService.java
+++ b/backend/src/main/java/com/swipelab/analytics/application/AnalyticsService.java
@@ -6,12 +6,14 @@ import com.swipelab.analytics.infrastructure.*;
 import com.swipelab.classification.domain.Classification.UserResponse;
 import com.swipelab.classification.infrastructure.ClassificationRepository;
 import com.swipelab.classification.infrastructure.ImageRepository;
+import com.swipelab.config.CacheConfig;
 import com.swipelab.dto.response.DashboardStatsResponse;
 import com.swipelab.dto.response.UserPerformanceResponse;
 import com.swipelab.tasks.domain.TaskStatus;
 import com.swipelab.tasks.infrastructure.TaskRepository;
 import com.swipelab.users.infrastructure.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -222,6 +224,7 @@ public class AnalyticsService {
      * confidence trend (last 30 days), and label distribution (last 30 days).
      * All date windows use server time (Asia/Jerusalem).
      */
+    @Cacheable(value = CacheConfig.CACHE_PLATFORM_OVERVIEW)
     @Transactional(readOnly = true)
     public PlatformOverviewResponse getPlatformOverview() {
         LocalDate today = LocalDate.now();

--- a/backend/src/main/java/com/swipelab/collection/application/CollectionService.java
+++ b/backend/src/main/java/com/swipelab/collection/application/CollectionService.java
@@ -4,8 +4,10 @@ import com.swipelab.collection.domain.UserCollectionEntry;
 import com.swipelab.collection.dto.CollectionEntryResponse;
 import com.swipelab.collection.dto.CollectionStatsResponse;
 import com.swipelab.collection.infrastructure.UserCollectionRepository;
+import com.swipelab.config.CacheConfig;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -49,6 +51,7 @@ public class CollectionService {
     }
 
     /** Returns aggregate stats for the user's collection. */
+    @Cacheable(value = CacheConfig.CACHE_COLLECTION_STATS, key = "#username")
     @Transactional(readOnly = true)
     public CollectionStatsResponse getStats(String username) {
         return CollectionStatsResponse.builder()

--- a/backend/src/main/java/com/swipelab/config/CacheConfig.java
+++ b/backend/src/main/java/com/swipelab/config/CacheConfig.java
@@ -1,0 +1,123 @@
+package com.swipelab.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.swipelab.integration.stardbi.StardbiClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.event.EventListener;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Central Caffeine cache configuration.
+ *
+ * Named caches with per-cache TTL and size caps. Per-user caches (gamificationInfo,
+ * collectionStats, userProfile) use username as the key; maximumSize=500 means the
+ * 500 most recently accessed users are retained (LRU for the rest).
+ *
+ * Cache warm-up: taxonomy data is pre-loaded on startup to avoid first-request
+ * latency spikes against the external Stardbi API.
+ */
+@Slf4j
+@Configuration
+@EnableCaching
+@RequiredArgsConstructor
+public class CacheConfig {
+
+    private final StardbiClient stardbiClient;
+
+    // ── Cache names ────────────────────────────────────────────────────────────
+
+    public static final String CACHE_LEADERBOARD      = "leaderboard";
+    public static final String CACHE_TAXONOMY         = "taxonomy";
+    public static final String CACHE_COLLECTION_STATS = "collectionStats";
+    public static final String CACHE_GAMIFICATION     = "gamificationInfo";
+    public static final String CACHE_ACTIVE_TASKS     = "activeTasks";
+    public static final String CACHE_TASK_DETAILS     = "taskDetails";
+    public static final String CACHE_USER_PROFILE     = "userProfile";
+    public static final String CACHE_PLATFORM_OVERVIEW = "platformOverview";
+
+    // ── CacheManager ──────────────────────────────────────────────────────────
+
+    @Bean
+    public CacheManager cacheManager() {
+        CaffeineCacheManager manager = new CaffeineCacheManager();
+
+        // Each cache gets its own Caffeine spec via individual registration.
+        // Spring Boot's CaffeineCacheManager supports per-cache specs when
+        // caches are registered explicitly before any @Cacheable call.
+        manager.registerCustomCache(CACHE_LEADERBOARD,
+                Caffeine.newBuilder()
+                        .maximumSize(10)
+                        .expireAfterWrite(60, TimeUnit.SECONDS)
+                        .build());
+
+        manager.registerCustomCache(CACHE_TAXONOMY,
+                Caffeine.newBuilder()
+                        .maximumSize(1)
+                        .expireAfterWrite(10, TimeUnit.MINUTES)
+                        .build());
+
+        manager.registerCustomCache(CACHE_COLLECTION_STATS,
+                Caffeine.newBuilder()
+                        .maximumSize(500)
+                        .expireAfterWrite(60, TimeUnit.SECONDS)
+                        .build());
+
+        manager.registerCustomCache(CACHE_GAMIFICATION,
+                Caffeine.newBuilder()
+                        .maximumSize(500)
+                        .expireAfterWrite(30, TimeUnit.SECONDS)
+                        .build());
+
+        manager.registerCustomCache(CACHE_ACTIVE_TASKS,
+                Caffeine.newBuilder()
+                        .maximumSize(50)
+                        .expireAfterWrite(2, TimeUnit.MINUTES)
+                        .build());
+
+        manager.registerCustomCache(CACHE_TASK_DETAILS,
+                Caffeine.newBuilder()
+                        .maximumSize(100)
+                        .expireAfterWrite(2, TimeUnit.MINUTES)
+                        .build());
+
+        manager.registerCustomCache(CACHE_USER_PROFILE,
+                Caffeine.newBuilder()
+                        .maximumSize(500)
+                        .expireAfterWrite(60, TimeUnit.SECONDS)
+                        .build());
+
+        manager.registerCustomCache(CACHE_PLATFORM_OVERVIEW,
+                Caffeine.newBuilder()
+                        .maximumSize(1)
+                        .expireAfterWrite(2, TimeUnit.MINUTES)
+                        .build());
+
+        return manager;
+    }
+
+    // ── Taxonomy warm-up ───────────────────────────────────────────────────────
+
+    /**
+     * Pre-populates the taxonomy cache once the application is fully started.
+     * Eliminates first-request latency against the external Stardbi API.
+     * If Stardbi is unavailable at startup, the cache populates lazily instead.
+     */
+    @EventListener(ApplicationReadyEvent.class)
+    public void warmTaxonomyCache() {
+        try {
+            log.info("Warming taxonomy cache on startup...");
+            stardbiClient.getTaxonomy();
+            log.info("Taxonomy cache warmed successfully.");
+        } catch (Exception e) {
+            log.warn("Taxonomy cache warm-up failed — will populate lazily on first request. Reason: {}", e.getMessage());
+        }
+    }
+}

--- a/backend/src/main/java/com/swipelab/config/CacheControlInterceptor.java
+++ b/backend/src/main/java/com/swipelab/config/CacheControlInterceptor.java
@@ -1,0 +1,130 @@
+package com.swipelab.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.CacheControl;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Applies Cache-Control headers to responses based on request path and method.
+ *
+ * Rules (evaluated top-to-bottom; first match wins):
+ *   - Non-GET/HEAD methods → no-store (mutations must never be cached)
+ *   - Sensitive / always-fresh paths → no-store
+ *   - Image content → public, max-age=86400 (immutable once uploaded)
+ *   - Shared public data (leaderboard) → public, max-age=60
+ *   - Per-user volatile data → private, max-age=30
+ *   - Per-user standard data → private, max-age=60
+ *   - Stable lookup data → private, max-age=120 or max-age=300
+ *   - User profile (always revalidate) → private, no-cache
+ *   - Everything else → no Cache-Control header added
+ *
+ * Registered in WebConfig.addInterceptors().
+ */
+@Component
+public class CacheControlInterceptor implements HandlerInterceptor {
+
+    // Pre-built CacheControl instances (immutable, safe to share)
+    private static final String NO_STORE          = CacheControl.noStore().getHeaderValue();
+    private static final String NO_CACHE_PRIVATE  = CacheControl.noCache().cachePrivate().getHeaderValue();
+    private static final String PUBLIC_1DAY       = CacheControl.maxAge(86400, TimeUnit.SECONDS).cachePublic().getHeaderValue();
+    private static final String PUBLIC_60S        = CacheControl.maxAge(60, TimeUnit.SECONDS).cachePublic().getHeaderValue();
+    private static final String PRIVATE_30S       = CacheControl.maxAge(30, TimeUnit.SECONDS).cachePrivate().getHeaderValue();
+    private static final String PRIVATE_60S       = CacheControl.maxAge(60, TimeUnit.SECONDS).cachePrivate().getHeaderValue();
+    private static final String PRIVATE_120S      = CacheControl.maxAge(120, TimeUnit.SECONDS).cachePrivate().getHeaderValue();
+    private static final String PRIVATE_300S      = CacheControl.maxAge(300, TimeUnit.SECONDS).cachePrivate().getHeaderValue();
+
+    private static final String CACHE_CONTROL     = "Cache-Control";
+
+    @Override
+    public boolean preHandle(HttpServletRequest request,
+                             HttpServletResponse response,
+                             Object handler) {
+
+        String method = request.getMethod();
+        String path   = request.getRequestURI();
+
+        // ── Non-GET/HEAD → always no-store ────────────────────────────────────
+        if (!HttpMethod.GET.matches(method) && !HttpMethod.HEAD.matches(method)) {
+            response.setHeader(CACHE_CONTROL, NO_STORE);
+            return true;
+        }
+
+        // ── Sensitive / must-not-cache ─────────────────────────────────────────
+        if (path.startsWith("/api/v1/auth/")
+                || path.startsWith("/health")
+                || path.startsWith("/api/v1/classifications/next-batch")) {
+            response.setHeader(CACHE_CONTROL, NO_STORE);
+            return true;
+        }
+
+        // ── Immutable binary content (images) ─────────────────────────────────
+        if (path.matches(".*/images/[^/]+/content")
+                || path.matches(".*/gold-images/[^/]+/image")) {
+            response.setHeader(CACHE_CONTROL, PUBLIC_1DAY);
+            return true;
+        }
+
+        // ── Shared public data ─────────────────────────────────────────────────
+        if (path.equals("/api/v1/gamification/leaderboard")) {
+            response.setHeader(CACHE_CONTROL, PUBLIC_60S);
+            return true;
+        }
+
+        // ── Per-user volatile (changes on every classification) ────────────────
+        if (path.startsWith("/api/v1/gamification/user-info")
+                || path.startsWith("/api/v1/gamification/rank")
+                || path.startsWith("/api/v1/classifications/progress")) {
+            response.setHeader(CACHE_CONTROL, PRIVATE_30S);
+            return true;
+        }
+
+        // ── User profile (always revalidate via ETag) ──────────────────────────
+        if (path.equals("/api/v1/users/me")) {
+            response.setHeader(CACHE_CONTROL, NO_CACHE_PRIVATE);
+            return true;
+        }
+
+        // ── Taxonomy / species metadata (10-min Caffeine TTL) ─────────────────
+        if (path.startsWith("/api/v1/metadata/")) {
+            response.setHeader(CACHE_CONTROL, PRIVATE_300S);
+            return true;
+        }
+
+        // ── Task details (stable once created) ────────────────────────────────
+        if (path.matches(".*/tasks/my-tasks/[^/]+")
+                || path.matches(".*/tasks/dashboard/[^/]+")) {
+            response.setHeader(CACHE_CONTROL, PRIVATE_120S);
+            return true;
+        }
+
+        // ── User public profile ────────────────────────────────────────────────
+        if (path.matches("/api/v1/users/[^/]+")) {
+            response.setHeader(CACHE_CONTROL, PRIVATE_120S);
+            return true;
+        }
+
+        // ── Analytics task-level (admin) ───────────────────────────────────────
+        if (path.startsWith("/api/v1/analytics/")) {
+            response.setHeader(CACHE_CONTROL, PRIVATE_120S);
+            return true;
+        }
+
+        // ── Standard private, 60 s ────────────────────────────────────────────
+        if (path.startsWith("/api/v1/tasks/")
+                || path.startsWith("/api/v1/gamification/")
+                || path.startsWith("/api/v1/collection")
+                || path.startsWith("/api/v1/statistics/")
+                || path.startsWith("/api/v1/classifications/")) {
+            response.setHeader(CACHE_CONTROL, PRIVATE_60S);
+            return true;
+        }
+
+        // ── Everything else: no header added (Spring default behaviour) ────────
+        return true;
+    }
+}

--- a/backend/src/main/java/com/swipelab/config/CacheEvictionListener.java
+++ b/backend/src/main/java/com/swipelab/config/CacheEvictionListener.java
@@ -1,0 +1,89 @@
+package com.swipelab.config;
+
+import com.swipelab.classification.events.ClassificationSubmittedEvent;
+import com.swipelab.gamification.events.GamificationUpdatedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Centralized cache eviction listener.
+ *
+ * Hooks into the existing Spring event system to invalidate stale cache entries
+ * after mutations. Keeps eviction logic out of business services — they publish
+ * events and this listener handles the cache consequences.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CacheEvictionListener {
+
+    private final CacheManager cacheManager;
+
+    // ── Classification submitted ───────────────────────────────────────────────
+
+    /**
+     * A classification changes: user's gamification score, collection stats,
+     * profile credibility, leaderboard ranking, and platform overview totals.
+     */
+    @EventListener
+    public void onClassificationSubmitted(ClassificationSubmittedEvent event) {
+        String username = event.getUsername();
+        if (username == null) {
+            log.warn("ClassificationSubmittedEvent received with null username — skipping cache eviction.");
+            return;
+        }
+
+        // Per-user caches
+        evict(CacheConfig.CACHE_GAMIFICATION, username);
+        evict(CacheConfig.CACHE_COLLECTION_STATS, username);
+        evict(CacheConfig.CACHE_USER_PROFILE, username);
+
+        // Shared caches
+        evictAll(CacheConfig.CACHE_LEADERBOARD);
+        evictAll(CacheConfig.CACHE_PLATFORM_OVERVIEW);
+
+        log.debug("Cache evicted after classification by user={}", username);
+    }
+
+    // ── Gamification updated ───────────────────────────────────────────────────
+
+    /**
+     * Handles explicit gamification updates (badge awards, score adjustments)
+     * published separately from the classification event flow.
+     */
+    @EventListener
+    public void onGamificationUpdated(GamificationUpdatedEvent event) {
+        String username = event.getUsername();
+        if (username == null) {
+            log.warn("GamificationUpdatedEvent received with null username — skipping cache eviction.");
+            return;
+        }
+
+        evict(CacheConfig.CACHE_GAMIFICATION, username);
+        evict(CacheConfig.CACHE_USER_PROFILE, username);
+
+        log.debug("Cache evicted after gamification update for user={}", username);
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────────
+
+    /** Evicts a single key from a named cache. No-op if the cache does not exist. */
+    private void evict(String cacheName, Object key) {
+        Cache cache = cacheManager.getCache(cacheName);
+        if (cache != null) {
+            cache.evict(key);
+        }
+    }
+
+    /** Clears every entry from a named cache. No-op if the cache does not exist. */
+    private void evictAll(String cacheName) {
+        Cache cache = cacheManager.getCache(cacheName);
+        if (cache != null) {
+            cache.clear();
+        }
+    }
+}

--- a/backend/src/main/java/com/swipelab/config/HttpCacheConfig.java
+++ b/backend/src/main/java/com/swipelab/config/HttpCacheConfig.java
@@ -1,0 +1,43 @@
+package com.swipelab.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.filter.ShallowEtagHeaderFilter;
+
+/**
+ * Registers the Spring ShallowEtagHeaderFilter.
+ *
+ * The filter computes an MD5 hash of each response body, sets the ETag response header,
+ * and returns 304 Not Modified when the client sends a matching If-None-Match request header.
+ *
+ * Binary content endpoints are excluded to prevent buffering large payloads in memory:
+ *   - /api/v1/images/{id}/content     (Stardbi image crops — can be megabytes)
+ *   - /api/admin/gold-images/{id}/image (gold-standard images)
+ *
+ * Cache-Control headers are applied separately by CacheControlInterceptor.
+ */
+@Configuration
+public class HttpCacheConfig {
+
+    @Bean
+    public FilterRegistrationBean<ShallowEtagHeaderFilter> shallowEtagHeaderFilter() {
+        ShallowEtagHeaderFilter filter = new ShallowEtagHeaderFilter() {
+            @Override
+            protected boolean shouldNotFilter(HttpServletRequest request) {
+                String path = request.getRequestURI();
+                // Skip ETag computation for binary image endpoints to avoid
+                // buffering the full image body in memory.
+                return path.matches(".*/images/[^/]+/content")
+                        || path.matches(".*/gold-images/[^/]+/image");
+            }
+        };
+
+        FilterRegistrationBean<ShallowEtagHeaderFilter> registration = new FilterRegistrationBean<>(filter);
+        registration.addUrlPatterns("/*");
+        registration.setName("shallowEtagHeaderFilter");
+        registration.setOrder(1);
+        return registration;
+    }
+}

--- a/backend/src/main/java/com/swipelab/config/WebConfig.java
+++ b/backend/src/main/java/com/swipelab/config/WebConfig.java
@@ -1,6 +1,8 @@
 package com.swipelab.config;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 // Static file serving for /uploads/** has been removed intentionally.
@@ -8,4 +10,12 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 // GET /api/admin/gold-images/{id}/image to avoid exposing filesystem structure.
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
+    @Autowired
+    private CacheControlInterceptor cacheControlInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(cacheControlInterceptor);
+    }
 }

--- a/backend/src/main/java/com/swipelab/gamification/domain/LeaderboardService.java
+++ b/backend/src/main/java/com/swipelab/gamification/domain/LeaderboardService.java
@@ -1,7 +1,9 @@
 package com.swipelab.gamification.domain;
 
+import com.swipelab.config.CacheConfig;
 import com.swipelab.gamification.infrastructure.GamificationRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
@@ -14,6 +16,7 @@ public class LeaderboardService {
 
     private final GamificationRepository gamificationRepository;
 
+    @Cacheable(value = CacheConfig.CACHE_LEADERBOARD, key = "#limit")
     public List<Gamification> getGlobalLeaderboard(int limit) {
         return gamificationRepository.findAll(
                 PageRequest.of(0, limit, Sort.by(Sort.Direction.DESC, "score"))).getContent();
@@ -24,6 +27,7 @@ public class LeaderboardService {
                 PageRequest.of(0, limit, Sort.by(Sort.Direction.DESC, "currentStreak"))).getContent();
     }
 
+    @Cacheable(value = CacheConfig.CACHE_GAMIFICATION, key = "#username")
     public Gamification getGamification(String username) {
         return gamificationRepository.findById(username)
                 .orElse(Gamification.builder()

--- a/backend/src/main/java/com/swipelab/integration/stardbi/StardbiClient.java
+++ b/backend/src/main/java/com/swipelab/integration/stardbi/StardbiClient.java
@@ -1,9 +1,11 @@
 package com.swipelab.integration.stardbi;
 
+import com.swipelab.config.CacheConfig;
 import com.swipelab.integration.stardbi.dto.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
@@ -148,6 +150,7 @@ public class StardbiClient {
     // TAXONOMY
     // ======================================
 
+    @Cacheable(value = CacheConfig.CACHE_TAXONOMY)
     public List<ExternalTaxonomyDto> getTaxonomy() {
         String url = baseUrl + "/swipe_lab/taxonomy/";
         HttpEntity<Void> entity = new HttpEntity<>(createAuthHeaders(getServiceAccountToken()));

--- a/backend/src/test/java/com/swipelab/config/CacheConfigTest.java
+++ b/backend/src/test/java/com/swipelab/config/CacheConfigTest.java
@@ -1,0 +1,94 @@
+package com.swipelab.config;
+
+import com.swipelab.integration.stardbi.StardbiClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CacheConfigTest {
+
+    @Mock
+    private StardbiClient stardbiClient;
+
+    @InjectMocks
+    private CacheConfig cacheConfig;
+
+    // ── Cache registration ─────────────────────────────────────────────────────
+
+    @Test
+    void cacheManager_ShouldRegisterAllExpectedCaches() {
+        CacheManager manager = cacheConfig.cacheManager();
+
+        assertThat(manager.getCache(CacheConfig.CACHE_LEADERBOARD)).isNotNull();
+        assertThat(manager.getCache(CacheConfig.CACHE_TAXONOMY)).isNotNull();
+        assertThat(manager.getCache(CacheConfig.CACHE_COLLECTION_STATS)).isNotNull();
+        assertThat(manager.getCache(CacheConfig.CACHE_GAMIFICATION)).isNotNull();
+        assertThat(manager.getCache(CacheConfig.CACHE_ACTIVE_TASKS)).isNotNull();
+        assertThat(manager.getCache(CacheConfig.CACHE_TASK_DETAILS)).isNotNull();
+        assertThat(manager.getCache(CacheConfig.CACHE_USER_PROFILE)).isNotNull();
+        assertThat(manager.getCache(CacheConfig.CACHE_PLATFORM_OVERVIEW)).isNotNull();
+    }
+
+    @Test
+    void cache_ShouldReturnSameValueOnRepeatedGet() {
+        CacheManager manager = cacheConfig.cacheManager();
+        Cache leaderboard = manager.getCache(CacheConfig.CACHE_LEADERBOARD);
+
+        leaderboard.put("key1", "value1");
+
+        Cache.ValueWrapper hit = leaderboard.get("key1");
+        assertThat(hit).isNotNull();
+        assertThat(hit.get()).isEqualTo("value1");
+    }
+
+    @Test
+    void cache_ShouldReturnNullAfterEviction() {
+        CacheManager manager = cacheConfig.cacheManager();
+        Cache cache = manager.getCache(CacheConfig.CACHE_GAMIFICATION);
+
+        cache.put("alice", "gamification-data");
+        cache.evict("alice");
+
+        assertThat(cache.get("alice")).isNull();
+    }
+
+    @Test
+    void cache_ShouldBeEmptyAfterClear() {
+        CacheManager manager = cacheConfig.cacheManager();
+        Cache cache = manager.getCache(CacheConfig.CACHE_LEADERBOARD);
+
+        cache.put(10, "top10");
+        cache.put(5, "top5");
+        cache.clear();
+
+        assertThat(cache.get(10)).isNull();
+        assertThat(cache.get(5)).isNull();
+    }
+
+    // ── Taxonomy warm-up ───────────────────────────────────────────────────────
+
+    @Test
+    void warmTaxonomyCache_ShouldCallGetTaxonomy() {
+        cacheConfig.warmTaxonomyCache();
+
+        verify(stardbiClient, times(1)).getTaxonomy();
+    }
+
+    @Test
+    void warmTaxonomyCache_ShouldNotPropagateException_WhenStardbiIsDown() {
+        doThrow(new RuntimeException("Stardbi unavailable")).when(stardbiClient).getTaxonomy();
+
+        // Must NOT throw — warm-up failure is non-fatal
+        cacheConfig.warmTaxonomyCache();
+
+        verify(stardbiClient, times(1)).getTaxonomy();
+    }
+}

--- a/backend/src/test/java/com/swipelab/config/CacheControlInterceptorTest.java
+++ b/backend/src/test/java/com/swipelab/config/CacheControlInterceptorTest.java
@@ -1,0 +1,136 @@
+package com.swipelab.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for CacheControlInterceptor.
+ *
+ * Note: Spring's CacheControl serializes directives as:
+ *   "max-age=N, private" (not "private, max-age=N")
+ *   "max-age=N, public" (not "public, max-age=N")
+ */
+class CacheControlInterceptorTest {
+
+    private CacheControlInterceptor interceptor;
+    private MockHttpServletResponse response;
+
+    @BeforeEach
+    void setUp() {
+        interceptor = new CacheControlInterceptor();
+        response = new MockHttpServletResponse();
+    }
+
+    // ── Helper ─────────────────────────────────────────────────────────────────
+
+    private void handle(String method, String path) throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest(method, path);
+        interceptor.preHandle(request, response, new Object());
+    }
+
+    // ── Happy paths ────────────────────────────────────────────────────────────
+
+    @Test
+    void GET_tasksList_ShouldSetPrivate60s() throws Exception {
+        handle("GET", "/api/v1/tasks/my-tasks");
+        assertThat(response.getHeader("Cache-Control")).isEqualTo("max-age=60, private");
+    }
+
+    @Test
+    void GET_availableTasks_ShouldSetPrivate60s() throws Exception {
+        handle("GET", "/api/v1/tasks/available-tasks");
+        assertThat(response.getHeader("Cache-Control")).isEqualTo("max-age=60, private");
+    }
+
+    @Test
+    void GET_speciesMetadata_ShouldSetPrivate300s() throws Exception {
+        handle("GET", "/api/v1/metadata/species");
+        assertThat(response.getHeader("Cache-Control")).isEqualTo("max-age=300, private");
+    }
+
+    @Test
+    void GET_leaderboard_ShouldSetPublic60s() throws Exception {
+        handle("GET", "/api/v1/gamification/leaderboard");
+        assertThat(response.getHeader("Cache-Control")).isEqualTo("max-age=60, public");
+    }
+
+    @Test
+    void GET_gamificationUserInfo_ShouldSetPrivate30s() throws Exception {
+        handle("GET", "/api/v1/gamification/user-info");
+        assertThat(response.getHeader("Cache-Control")).isEqualTo("max-age=30, private");
+    }
+
+    @Test
+    void GET_userMe_ShouldSetNoCachePrivate() throws Exception {
+        handle("GET", "/api/v1/users/me");
+        // no-cache + private → "no-cache, private"
+        assertThat(response.getHeader("Cache-Control")).contains("no-cache");
+        assertThat(response.getHeader("Cache-Control")).contains("private");
+    }
+
+    @Test
+    void GET_imageContent_ShouldSetPublic1Day() throws Exception {
+        handle("GET", "/api/v1/images/42/content");
+        assertThat(response.getHeader("Cache-Control")).isEqualTo("max-age=86400, public");
+    }
+
+    @Test
+    void GET_goldImage_ShouldSetPublic1Day() throws Exception {
+        handle("GET", "/api/admin/gold-images/7/image");
+        assertThat(response.getHeader("Cache-Control")).isEqualTo("max-age=86400, public");
+    }
+
+    @Test
+    void GET_collectionStats_ShouldSetPrivate60s() throws Exception {
+        handle("GET", "/api/v1/collection/stats");
+        assertThat(response.getHeader("Cache-Control")).isEqualTo("max-age=60, private");
+    }
+
+    // ── Sensitive / no-store edge cases ───────────────────────────────────────
+
+    @Test
+    void POST_anyPath_ShouldSetNoStore() throws Exception {
+        handle("POST", "/api/v1/tasks/create");
+        assertThat(response.getHeader("Cache-Control")).isEqualTo("no-store");
+    }
+
+    @Test
+    void PUT_anyPath_ShouldSetNoStore() throws Exception {
+        handle("PUT", "/api/v1/tasks/1");
+        assertThat(response.getHeader("Cache-Control")).isEqualTo("no-store");
+    }
+
+    @Test
+    void DELETE_anyPath_ShouldSetNoStore() throws Exception {
+        handle("DELETE", "/api/v1/tasks/1");
+        assertThat(response.getHeader("Cache-Control")).isEqualTo("no-store");
+    }
+
+    @Test
+    void GET_authEndpoint_ShouldSetNoStore() throws Exception {
+        handle("GET", "/api/v1/auth/refresh");
+        assertThat(response.getHeader("Cache-Control")).isEqualTo("no-store");
+    }
+
+    @Test
+    void GET_health_ShouldSetNoStore() throws Exception {
+        handle("GET", "/health");
+        assertThat(response.getHeader("Cache-Control")).isEqualTo("no-store");
+    }
+
+    @Test
+    void GET_nextBatch_ShouldSetNoStore() throws Exception {
+        handle("GET", "/api/v1/classifications/next-batch");
+        assertThat(response.getHeader("Cache-Control")).isEqualTo("no-store");
+    }
+
+    @Test
+    void GET_unknownPath_ShouldNotSetCacheControlHeader() throws Exception {
+        handle("GET", "/api/v1/some/unknown/endpoint");
+        assertThat(response.getHeader("Cache-Control")).isNull();
+    }
+}

--- a/backend/src/test/java/com/swipelab/config/CacheEvictionListenerTest.java
+++ b/backend/src/test/java/com/swipelab/config/CacheEvictionListenerTest.java
@@ -1,0 +1,117 @@
+package com.swipelab.config;
+
+import com.swipelab.classification.domain.Classification.UserResponse;
+import com.swipelab.classification.events.ClassificationSubmittedEvent;
+import com.swipelab.gamification.events.GamificationUpdatedEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class CacheEvictionListenerTest {
+
+    @Mock
+    private CacheManager cacheManager;
+
+    @Mock
+    private Cache gamificationCache;
+
+    @Mock
+    private Cache collectionStatsCache;
+
+    @Mock
+    private Cache userProfileCache;
+
+    @Mock
+    private Cache leaderboardCache;
+
+    @Mock
+    private Cache platformOverviewCache;
+
+    private CacheEvictionListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new CacheEvictionListener(cacheManager);
+
+        when(cacheManager.getCache(CacheConfig.CACHE_GAMIFICATION)).thenReturn(gamificationCache);
+        when(cacheManager.getCache(CacheConfig.CACHE_COLLECTION_STATS)).thenReturn(collectionStatsCache);
+        when(cacheManager.getCache(CacheConfig.CACHE_USER_PROFILE)).thenReturn(userProfileCache);
+        when(cacheManager.getCache(CacheConfig.CACHE_LEADERBOARD)).thenReturn(leaderboardCache);
+        when(cacheManager.getCache(CacheConfig.CACHE_PLATFORM_OVERVIEW)).thenReturn(platformOverviewCache);
+    }
+
+    // ── ClassificationSubmittedEvent ───────────────────────────────────────────
+
+    @Test
+    void onClassificationSubmitted_ShouldEvictUserSpecificAndSharedCaches() {
+        ClassificationSubmittedEvent event = ClassificationSubmittedEvent.builder()
+                .username("alice")
+                .imageId(1L)
+                .taskId(1L)
+                .userResponse(UserResponse.YES)
+                .build();
+
+        listener.onClassificationSubmitted(event);
+
+        // Per-user evictions
+        verify(gamificationCache).evict("alice");
+        verify(collectionStatsCache).evict("alice");
+        verify(userProfileCache).evict("alice");
+
+        // Shared cache clears
+        verify(leaderboardCache).clear();
+        verify(platformOverviewCache).clear();
+    }
+
+    @Test
+    void onClassificationSubmitted_WithNullUsername_ShouldNotThrow() {
+        ClassificationSubmittedEvent event = ClassificationSubmittedEvent.builder()
+                .username(null)
+                .build();
+
+        // Must be a no-op — no NPE, no cache interaction
+        listener.onClassificationSubmitted(event);
+
+        verifyNoInteractions(gamificationCache, collectionStatsCache, userProfileCache,
+                leaderboardCache, platformOverviewCache);
+    }
+
+    // ── GamificationUpdatedEvent ───────────────────────────────────────────────
+
+    @Test
+    void onGamificationUpdated_ShouldEvictGamificationAndUserProfile() {
+        GamificationUpdatedEvent event = GamificationUpdatedEvent.builder()
+                .username("bob")
+                .score(1500L)
+                .build();
+
+        listener.onGamificationUpdated(event);
+
+        verify(gamificationCache).evict("bob");
+        verify(userProfileCache).evict("bob");
+
+        // Leaderboard and platform overview NOT touched by this event
+        verifyNoInteractions(leaderboardCache, platformOverviewCache);
+    }
+
+    @Test
+    void onGamificationUpdated_WithNullUsername_ShouldNotThrow() {
+        GamificationUpdatedEvent event = GamificationUpdatedEvent.builder()
+                .username(null)
+                .build();
+
+        listener.onGamificationUpdated(event);
+
+        verifyNoInteractions(gamificationCache, userProfileCache);
+    }
+}

--- a/backend/src/test/java/com/swipelab/config/ETagIntegrationTest.java
+++ b/backend/src/test/java/com/swipelab/config/ETagIntegrationTest.java
@@ -1,0 +1,142 @@
+package com.swipelab.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.filter.ShallowEtagHeaderFilter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests the ShallowEtagHeaderFilter behaviour directly using MockServlet objects.
+ *
+ * Verifies:
+ *  - First GET → 200 with ETag header present
+ *  - Second GET with matching If-None-Match → 304 Not Modified with empty body
+ *  - Stale ETag → 200 with a new ETag value
+ *  - Binary-excluded paths → no ETag header (shouldNotFilter override)
+ */
+class ETagIntegrationTest {
+
+    /**
+     * Inline subclass mirroring the shouldNotFilter logic from HttpCacheConfig.
+     */
+    private static class TestEtagFilter extends ShallowEtagHeaderFilter {
+        @Override
+        protected boolean shouldNotFilter(HttpServletRequest request) {
+            String path = request.getRequestURI();
+            return path.matches(".*/images/[^/]+/content")
+                    || path.matches(".*/gold-images/[^/]+/image");
+        }
+    }
+
+    // ── Servlet stubs that write a fixed body ──────────────────────────────────
+
+    /** Writes a JSON leaderboard body. */
+    private static final HttpServlet LEADERBOARD_SERVLET = new HttpServlet() {
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse res)
+                throws java.io.IOException {
+            res.setContentType("application/json");
+            res.getWriter().write("{\"data\":\"leaderboard\"}");
+        }
+    };
+
+    /** Writes a different JSON body to produce a new ETag. */
+    private static final HttpServlet UPDATED_LEADERBOARD_SERVLET = new HttpServlet() {
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse res)
+                throws java.io.IOException {
+            res.setContentType("application/json");
+            res.getWriter().write("{\"data\":\"updated-leaderboard\"}");
+        }
+    };
+
+    /** Writes binary image bytes. */
+    private static final HttpServlet IMAGE_SERVLET = new HttpServlet() {
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse res)
+                throws java.io.IOException {
+            res.setContentType("image/jpeg");
+            res.getOutputStream().write(new byte[]{(byte) 0xFF, (byte) 0xD8});
+        }
+    };
+
+    private TestEtagFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        filter = new TestEtagFilter();
+    }
+
+    // ── Happy path: 200 + ETag on first request ────────────────────────────────
+
+    @Test
+    void firstRequest_ShouldReturn200_WithEtagHeader() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/gamification/leaderboard");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain(LEADERBOARD_SERVLET));
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeader("ETag")).isNotNull();
+    }
+
+    // ── Happy path: matching ETag → 304 ───────────────────────────────────────
+
+    @Test
+    void secondRequest_WithMatchingEtag_ShouldReturn304_WithEmptyBody() throws Exception {
+        // First request to capture ETag
+        MockHttpServletRequest firstRequest = new MockHttpServletRequest("GET", "/api/v1/gamification/leaderboard");
+        MockHttpServletResponse firstResponse = new MockHttpServletResponse();
+        filter.doFilter(firstRequest, firstResponse, new MockFilterChain(LEADERBOARD_SERVLET));
+        String etag = firstResponse.getHeader("ETag");
+        assertThat(etag).isNotNull();
+
+        // Second request with If-None-Match
+        MockHttpServletRequest secondRequest = new MockHttpServletRequest("GET", "/api/v1/gamification/leaderboard");
+        secondRequest.addHeader("If-None-Match", etag);
+        MockHttpServletResponse secondResponse = new MockHttpServletResponse();
+        filter.doFilter(secondRequest, secondResponse, new MockFilterChain(LEADERBOARD_SERVLET));
+
+        assertThat(secondResponse.getStatus()).isEqualTo(304);
+        assertThat(secondResponse.getContentAsString()).isEmpty();
+    }
+
+    // ── Edge case: stale ETag → 200 with new ETag ─────────────────────────────
+
+    @Test
+    void secondRequest_WithStaleEtag_ShouldReturn200_WithNewEtag() throws Exception {
+        String staleEtag = "\"00000000000000000000000000000000\"";
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/gamification/leaderboard");
+        request.addHeader("If-None-Match", staleEtag);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain(UPDATED_LEADERBOARD_SERVLET));
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        String newEtag = response.getHeader("ETag");
+        assertThat(newEtag).isNotNull().isNotEqualTo(staleEtag);
+    }
+
+    // ── Edge case: binary endpoint bypassed → no ETag header ─────────────────
+
+    @Test
+    void imageContentEndpoint_ShouldNotHaveEtagHeader() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/images/42/content");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain(IMAGE_SERVLET));
+
+        // Filter was bypassed — no ETag header should be set
+        assertThat(response.getHeader("ETag")).isNull();
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+}


### PR DESCRIPTION
This PR implements a comprehensive two-layer caching strategy to significantly reduce database load, minimize external API calls (Stardbi), and save network bandwidth for the mobile client.

The Two-Layer Approach:

Application Cache (Caffeine): An in-memory JVM cache that prevents expensive DB queries and external API calls.
HTTP Cache (ETag + Cache-Control): Intercepts HTTP requests and returns a 304 Not Modified without a response body if the data hasn't changed, saving bandwidth and serialization time.
1. Application Caching (Layer 1)
Caffeine Cache Manager: Configured spring-boot-starter-cache with Caffeine (CacheConfig.java). Created 8 named caches with specific size limits and TTLs (Time-To-Live).
Service Annotations: Applied @Cacheable to expensive read operations:
LeaderboardService (Global leaderboard and user gamification info)
CollectionService (Collection stats)
AnalyticsService (Platform overview)
StardbiClient (Taxonomy fetching)
Event-Driven Eviction: Created CacheEvictionListener.java that listens to existing Spring domain events (ClassificationSubmittedEvent, GamificationUpdatedEvent) to automatically invalidate stale caches without muddying business logic.
Startup Warm-up: The taxonomy cache is now automatically pre-fetched on application startup (ApplicationReadyEvent) to prevent latency spikes on the first user request.
2. HTTP Caching (Layer 2)
ShallowEtagHeaderFilter: Registered via HttpCacheConfig.java to automatically compute MD5 hashes of response bodies. When the client sends a matching If-None-Match header, the server returns a 304 Not Modified response. Excludes large binary image endpoints to prevent memory buffering.
Cache-Control Headers: Created CacheControlInterceptor.java to automatically apply appropriate Cache-Control headers based on the endpoint path:
public, max-age=86400: Immutable binary images (massive performance win for client).
private, max-age=X: Volatile and user-specific endpoints (tasks, gamification).
no-store: Applied universally to all POST/PUT/DELETE methods, authentication endpoints, and sensitive/always-fresh endpoints.
Testing & Verification
Added comprehensive unit tests for CacheConfig, CacheEvictionListener, and CacheControlInterceptor.
Added ETagIntegrationTest to verify the exact behavior of ShallowEtagHeaderFilter directly with MockHttpServletRequest/Response.
All 30 tests pass cleanly.