### PR TITLE
Fix: Assigned task not appearing after pressing + (stale HTTP cache bug)

### DIFF
--- a/backend/src/main/java/com/swipelab/config/CacheControlInterceptor.java
+++ b/backend/src/main/java/com/swipelab/config/CacheControlInterceptor.java
@@ -102,6 +102,16 @@ public class CacheControlInterceptor implements HandlerInterceptor {
             return true;
         }
 
+        // ── Personalised task lists (change on every assignment) ──────────────
+        // These are per-user and mutate the moment the user self-assigns a task.
+        // Any HTTP cache here would race with the frontend refetch and serve
+        // stale data, so they must always go to the network.
+        if (path.equals("/api/v1/tasks/my-tasks")
+                || path.equals("/api/v1/tasks/available-tasks")) {
+            response.setHeader(CACHE_CONTROL, NO_STORE);
+            return true;
+        }
+
         // ── User public profile ────────────────────────────────────────────────
         if (path.matches("/api/v1/users/[^/]+")) {
             response.setHeader(CACHE_CONTROL, PRIVATE_120S);

--- a/backend/src/main/java/com/swipelab/config/MockDataSeeder.java
+++ b/backend/src/main/java/com/swipelab/config/MockDataSeeder.java
@@ -173,6 +173,7 @@ public class MockDataSeeder implements CommandLineRunner {
                     .status(TaskStatus.ACTIVE)
                     .minClassificationsPerImage(3)
                     .consensusThreshold(80.0)
+                    .isPublic(false)
                     .deadline(LocalDateTime.now().plusDays(30))
                     .build();
 
@@ -190,8 +191,32 @@ public class MockDataSeeder implements CommandLineRunner {
                     .priority(1)
                     .build();
 
-            imageRepository.saveAll(List.of(img1, img2));
-            log.info("Seeded Tasks and Images.");
+            // Seed a second, public task that is not assigned to user_mock
+            // to allow testing of the task assignment and cache-update flow.
+            Task exploreTask = Task.builder()
+                    .title("Explore Mock Task")
+                    .name("explore_mock_task")
+                    .description("Identify birds in these mock images")
+                    .querySpecies("Birds")
+                    .question("Is this a Bird?")
+                    .createdBy(admin.getUsername())
+                    .status(TaskStatus.ACTIVE)
+                    .minClassificationsPerImage(3)
+                    .consensusThreshold(80.0)
+                    .isPublic(true)
+                    .deadline(LocalDateTime.now().plusDays(30))
+                    .build();
+
+            taskRepository.save(exploreTask);
+
+            Image img3 = Image.builder()
+                    .srcPath("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=")
+                    .taskId(exploreTask.getId())
+                    .priority(1)
+                    .build();
+
+            imageRepository.saveAll(List.of(img1, img2, img3));
+            log.info("Seeded Tasks and Images (including public explore task).");
         }
     }
     

--- a/backend/src/main/resources/db/migration/V15__add_task_assignment_schema.sql
+++ b/backend/src/main/resources/db/migration/V15__add_task_assignment_schema.sql
@@ -1,0 +1,28 @@
+-- ============================================================
+-- V15 – Task assignment schema: is_public flag + assigned users table
+-- Issue: [Frontend] tasks assign not updating because cached myTasksScreen
+-- ============================================================
+
+-- ── 1. Public task flag ───────────────────────────────────────
+-- Allows a task to appear in the public "Explore Tasks" list,
+-- where any authenticated user can self-assign.
+ALTER TABLE tasks ADD COLUMN IF NOT EXISTS is_public BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- ── 2. Task → assigned users join table ──────────────────────
+-- Tracks which usernames have self-assigned a public task via
+-- POST /api/v1/tasks/{id}/assign.
+CREATE TABLE IF NOT EXISTS task_assigned_users (
+    task_id  BIGINT       NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+    username VARCHAR(255) NOT NULL REFERENCES users(username) ON DELETE CASCADE,
+    PRIMARY KEY (task_id, username)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tau_task_id  ON task_assigned_users(task_id);
+CREATE INDEX IF NOT EXISTS idx_tau_username ON task_assigned_users(username);
+
+-- ── 3. Task extra columns used by Task entity ─────────────────
+-- These columns exist in the JPA entity but were never formally
+-- migrated; add them safely with IF NOT EXISTS semantics.
+ALTER TABLE tasks ADD COLUMN IF NOT EXISTS query_species   VARCHAR(255);
+ALTER TABLE tasks ADD COLUMN IF NOT EXISTS question        VARCHAR(500);
+ALTER TABLE tasks ADD COLUMN IF NOT EXISTS source_system   VARCHAR(50)  NOT NULL DEFAULT 'INTERNAL';

--- a/backend/src/test/java/com/swipelab/config/CacheControlInterceptorTest.java
+++ b/backend/src/test/java/com/swipelab/config/CacheControlInterceptorTest.java
@@ -35,15 +35,17 @@ class CacheControlInterceptorTest {
     // ── Happy paths ────────────────────────────────────────────────────────────
 
     @Test
-    void GET_tasksList_ShouldSetPrivate60s() throws Exception {
+    void GET_tasksList_ShouldSetNoStore() throws Exception {
+        // my-tasks is per-user and mutates on self-assignment — must never be browser-cached
         handle("GET", "/api/v1/tasks/my-tasks");
-        assertThat(response.getHeader("Cache-Control")).isEqualTo("max-age=60, private");
+        assertThat(response.getHeader("Cache-Control")).isEqualTo("no-store");
     }
 
     @Test
-    void GET_availableTasks_ShouldSetPrivate60s() throws Exception {
+    void GET_availableTasks_ShouldSetNoStore() throws Exception {
+        // available-tasks shrinks immediately after assignment — must never be browser-cached
         handle("GET", "/api/v1/tasks/available-tasks");
-        assertThat(response.getHeader("Cache-Control")).isEqualTo("max-age=60, private");
+        assertThat(response.getHeader("Cache-Control")).isEqualTo("no-store");
     }
 
     @Test

--- a/frontend/app/api/__tests__/useAssignTask.test.ts
+++ b/frontend/app/api/__tests__/useAssignTask.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for useAssignTask cache-refresh behaviour (Issue: myTasksScreen stale cache).
+ *
+ * Why: invalidateQueries only marks a query stale; it will NOT trigger a network
+ * request unless the component re-renders or window is re-focused.
+ * refetchQueries(type:'active') forces an immediate fetch for every mounted subscriber,
+ * which is what we want when the user presses the assign (+) button.
+ */
+import { renderHook, act } from '@testing-library/react-hooks';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { useAssignTask, QUERY_KEYS } from '../queries';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(() => Promise.resolve('mock_token')),
+}));
+
+jest.mock('../../stores/authStore', () => ({
+  useAuthStore: {
+    getState: jest.fn(() => ({
+      setIsBanned: jest.fn(),
+      setSessionExpiredMessage: jest.fn(),
+      logout: jest.fn(),
+    })),
+  },
+}));
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const buildWrapper = (queryClient: QueryClient) => {
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+};
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('useAssignTask', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  // Happy flow: successful assignment triggers immediate refetch of all three queries
+  it('refetches myTasks, availableTasks, and statistics on successful assignment', async () => {
+    // Simulate a successful POST /tasks/:id/assign response
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ taskId: 42, name: 'Example' }),
+      clone: () => ({ json: async () => ({}) }),
+    });
+
+    const refetchQueriesSpy = jest.spyOn(queryClient, 'refetchQueries');
+
+    const wrapper = buildWrapper(queryClient);
+    const { result } = renderHook(() => useAssignTask(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync(42);
+    });
+
+    // All three cache buckets must be scheduled for an active refetch
+    const calledKeys = refetchQueriesSpy.mock.calls.map(
+      (args) => JSON.stringify((args[0] as any)?.queryKey),
+    );
+
+    expect(calledKeys).toContain(JSON.stringify(QUERY_KEYS.myTasks));
+    expect(calledKeys).toContain(JSON.stringify(QUERY_KEYS.availableTasks));
+    expect(calledKeys).toContain(JSON.stringify(QUERY_KEYS.statistics));
+  });
+
+  // Edge case: 409 Conflict (already assigned) must NOT trigger any cache refetch
+  it('does NOT refetch queries on 409 (already assigned) error', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 409,
+      json: async () => ({ message: 'Task already assigned' }),
+      clone: () => ({ json: async () => ({}) }),
+    });
+
+    const refetchQueriesSpy = jest.spyOn(queryClient, 'refetchQueries');
+
+    const wrapper = buildWrapper(queryClient);
+    const { result } = renderHook(() => useAssignTask(), { wrapper });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync(42);
+      } catch {
+        // expected rejection
+      }
+    });
+
+    expect(refetchQueriesSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/app/api/queries.ts
+++ b/frontend/app/api/queries.ts
@@ -283,9 +283,12 @@ export const useAssignTask = () => {
       return res.json();
     },
     onSuccess: () => {
-      // Refresh both lists so the task moves from Explore → Assigned
-      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.myTasks });
-      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.availableTasks });
+      // Force an immediate refetch (not just stale-invalidation) so the task
+      // moves from Explore → Assigned without waiting for the background cycle.
+      queryClient.refetchQueries({ queryKey: QUERY_KEYS.myTasks, type: 'active' });
+      queryClient.refetchQueries({ queryKey: QUERY_KEYS.availableTasks, type: 'active' });
+      // Also refresh stat chips (Assigned / Classified counters in the header)
+      queryClient.refetchQueries({ queryKey: QUERY_KEYS.statistics, type: 'active' });
     },
   });
 };

--- a/frontend/app/components/ui/ErrorToast.tsx
+++ b/frontend/app/components/ui/ErrorToast.tsx
@@ -1,0 +1,83 @@
+import React, { useEffect, useRef } from 'react';
+import { Animated, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+interface ErrorToastProps {
+    message: string;
+    onDismiss: () => void;
+    /** Auto-dismiss delay in ms. Defaults to 4000. */
+    durationMs?: number;
+}
+
+/**
+ * Generic animated error toast.
+ * Slides in from the top, auto-dismisses after `durationMs`, and exposes a
+ * manual dismiss button. No browser/OS dialogs — fully app-native.
+ */
+export default function ErrorToast({ message, onDismiss, durationMs = 4000 }: ErrorToastProps) {
+    const opacity    = useRef(new Animated.Value(0)).current;
+    const translateY = useRef(new Animated.Value(-20)).current;
+
+    useEffect(() => {
+        // Slide in
+        Animated.parallel([
+            Animated.timing(opacity,    { toValue: 1, duration: 300, useNativeDriver: true }),
+            Animated.timing(translateY, { toValue: 0, duration: 300, useNativeDriver: true }),
+        ]).start();
+
+        // Auto-dismiss
+        const timer = setTimeout(dismiss, durationMs);
+        return () => clearTimeout(timer);
+    }, []);
+
+    const dismiss = () => {
+        Animated.parallel([
+            Animated.timing(opacity,    { toValue: 0, duration: 250, useNativeDriver: true }),
+            Animated.timing(translateY, { toValue: -20, duration: 250, useNativeDriver: true }),
+        ]).start(onDismiss);
+    };
+
+    return (
+        <Animated.View
+            style={[styles.container, { opacity, transform: [{ translateY }] }]}
+            accessibilityRole="alert"
+            accessibilityLabel={`Error: ${message}`}
+        >
+            <Ionicons name="alert-circle" size={20} color="#fca5a5" style={styles.icon} />
+            <Text style={styles.message} numberOfLines={3}>{message}</Text>
+            <TouchableOpacity onPress={dismiss} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+                <Ionicons name="close" size={18} color="#fff9" />
+            </TouchableOpacity>
+        </Animated.View>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        position: 'absolute',
+        top: 16,
+        left: 16,
+        right: 16,
+        zIndex: 999,
+        flexDirection: 'row',
+        alignItems: 'center',
+        backgroundColor: '#7f1d1d',
+        borderLeftColor: '#ef4444',
+        borderLeftWidth: 4,
+        borderRadius: 12,
+        padding: 14,
+        shadowColor: '#000',
+        shadowOpacity: 0.3,
+        shadowRadius: 10,
+        elevation: 8,
+    },
+    icon: {
+        marginRight: 10,
+    },
+    message: {
+        flex: 1,
+        color: '#fef2f2',
+        fontSize: 13,
+        lineHeight: 18,
+    },
+});

--- a/frontend/app/screens/user/UserMyTasksScreen.tsx
+++ b/frontend/app/screens/user/UserMyTasksScreen.tsx
@@ -1,7 +1,16 @@
 import { useNavigation } from '@react-navigation/native';
 import React, { useCallback } from 'react';
 import { useMyTasks, useAvailableTasks, useStatistics, useAssignTask } from "../../api/queries";
-import { Alert, RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Alert, Platform, RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
+
+// Alert.alert is a no-op on web — use this wrapper instead.
+const showError = (title: string, message: string) => {
+    if (Platform.OS === 'web') {
+        window.alert(`${title}\n\n${message}`);
+    } else {
+        Alert.alert(title, message);
+    }
+};
 import { Ionicons } from '@expo/vector-icons';
 import { Colors } from '../../../constants/theme';
 
@@ -33,11 +42,12 @@ export default function UserMyTasksScreen() {
     const assignTask = useAssignTask();
 
     const handleAddTask = async (taskId: number) => {
+        if (assignTask.isPending) return; // prevent double-tap
         try {
             await assignTask.mutateAsync(taskId);
-            // Cache is refreshed via onSuccess in useAssignTask; nothing more needed here.
+            // Cache is refreshed via refetchQueries in useAssignTask.onSuccess.
         } catch (err: any) {
-            Alert.alert('Could not add task', err?.message ?? 'An unexpected error occurred.');
+            showError('Could not add task', err?.message ?? 'An unexpected error occurred.');
         }
     };
 

--- a/frontend/app/screens/user/UserMyTasksScreen.tsx
+++ b/frontend/app/screens/user/UserMyTasksScreen.tsx
@@ -1,21 +1,13 @@
 import { useNavigation } from '@react-navigation/native';
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useMyTasks, useAvailableTasks, useStatistics, useAssignTask } from "../../api/queries";
-import { Alert, Platform, RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
-
-// Alert.alert is a no-op on web — use this wrapper instead.
-const showError = (title: string, message: string) => {
-    if (Platform.OS === 'web') {
-        window.alert(`${title}\n\n${message}`);
-    } else {
-        Alert.alert(title, message);
-    }
-};
+import { RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { Colors } from '../../../constants/theme';
 
 import ScreenHeaderLayout from '../../components/layout/ScreenHeaderLayout/ScreenHeaderLayout';
 import TaskCard from '../../components/user/TaskCard';
+import ErrorToast from '../../components/ui/ErrorToast';
 import { useThemeStore } from '../../stores/themeStore';
 import { useSwipeStore } from '../../stores/swipeStore';
 
@@ -26,6 +18,8 @@ export default function UserMyTasksScreen() {
     const themeColors = Colors[theme as keyof typeof Colors];
     const isDark = theme === 'dark';
     const { setActiveTaskId } = useSwipeStore();
+
+    const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
     const { data: stats, isLoading: statsLoading, refetch: refetchStats } = useStatistics();
     const { data: tasks = [], isLoading: tasksLoading, refetch: refetchTasks } = useMyTasks();
@@ -47,7 +41,7 @@ export default function UserMyTasksScreen() {
             await assignTask.mutateAsync(taskId);
             // Cache is refreshed via refetchQueries in useAssignTask.onSuccess.
         } catch (err: any) {
-            showError('Could not add task', err?.message ?? 'An unexpected error occurred.');
+            setErrorMsg(err?.message ?? 'Could not add task. Please try again.');
         }
     };
 
@@ -87,6 +81,13 @@ export default function UserMyTasksScreen() {
             rightTitle={`Completion: ${completionPercent}%`}
             contentContainerStyle={{ padding: 0 }}
         >
+            {/* App-native error toast — shown when task assignment fails */}
+            {errorMsg && (
+                <ErrorToast
+                    message={errorMsg}
+                    onDismiss={() => setErrorMsg(null)}
+                />
+            )}
             <ScrollView
                 style={{ backgroundColor: themeColors.background }}
                 contentContainerStyle={[styles.scrollContent, { backgroundColor: themeColors.background }]}


### PR DESCRIPTION
Root cause: CacheControlInterceptor applied `max-age=60` to /my-tasks and
/available-tasks. After a successful self-assignment, the frontend refetch
hit the browser cache instead of the server, returning stale data for up
to 60 seconds.
Changes:
- Backend: Set `no-store` on /my-tasks and /available-tasks endpoints
- Frontend: Use refetchQueries (forced) instead of invalidateQueries (lazy)
- Frontend: Fix silent error swallowing on web (Alert.alert no-op)
- Backend: V15 migration for missing is_public and task_assigned_users schema
- Mock: Add a public unassigned task to the seeder for local testing
Tested locally with mock profile: task immediately moves from Explore →
Assigned on first press. Browser DevTools confirmed no-store header on both
list endpoints.