### PR TITLE
Fix Task Image Counts in Researcher Dashboard (Issue #222)

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -29,12 +29,13 @@ Architecture: Modular Hexagonal/DDD.
 * Frontend/Backend: Fixed immediate logout bug for Researchers (Issue #225) by correcting the Stardbi token refresh flow. Updated `apiFetch` to use `backendUrl` for the refresh request (fixing React Native relative URL crashes) and fixed backend `StardbiAuthProvider` to properly pad incoming Base64Url JWT payloads before decoding, allowing newly refreshed tokens to be cached and validated.
 
 
+* Backend: Fixed task image count display in `TasksManagementScreen` (Issue #222). Replaced hardcoded zeros in `TaskMapper` by injecting `ImageRepository` and `ClassificationRepository` into `TaskService` to query real task image totals and distinct classified image counts.
+
 ## Current Focus (Active GitHub Issues)
 * Issue #201: Refactor Backend roles to include Researchers and Super Admin.
 * Issue #226: [Frontend] fix recipients list not deleting users.
 * Issue #225: [System] fix refresh token for Researcher.
 * Issue #224: [Frontend] Mobile Vs. Web compatibility enhancement.
-* Issue #222: [Frontend] fix TasksManagementScreen UI.
 * Issue #219: [Frontend] Add to UsersScreen ONLY for Admin role control buttons.
 
 ## Architecture & Design Decisions

--- a/backend/src/main/java/com/swipelab/classification/infrastructure/ClassificationRepository.java
+++ b/backend/src/main/java/com/swipelab/classification/infrastructure/ClassificationRepository.java
@@ -102,6 +102,15 @@ public interface ClassificationRepository extends JpaRepository<Classification, 
      */
     List<Classification> findByTaskIdIn(List<Long> taskIds);
 
+    /**
+     * Count distinct images in a task that have at least one classification.
+     * Used to compute TaskProgressResponse.imagesClassified.
+     * NOTE: threshold-gated "done" count is a future enhancement — this is a
+     * simple "touched" count until the consensus threshold feature is built.
+     */
+    @Query("SELECT COUNT(DISTINCT c.image.id) FROM Classification c WHERE c.taskId = :taskId")
+    long countDistinctImagesByTaskId(@Param("taskId") Long taskId);
+
     // ── Per-image-query credibility helpers ───────────────────────────────────
 
     /**

--- a/backend/src/main/java/com/swipelab/classification/infrastructure/ImageRepository.java
+++ b/backend/src/main/java/com/swipelab/classification/infrastructure/ImageRepository.java
@@ -14,6 +14,8 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
 
     List<Image> findByTaskId(Long taskId);
 
+    long countByTaskId(Long taskId);
+
     boolean existsByExternalBoxId(Long externalBoxId);
     Image findByExternalBoxId(Long externalBoxId);
 

--- a/backend/src/main/java/com/swipelab/tasks/application/TaskService.java
+++ b/backend/src/main/java/com/swipelab/tasks/application/TaskService.java
@@ -14,6 +14,9 @@ import com.swipelab.tasks.domain.TaskStatus;
 import com.swipelab.tasks.infrastructure.TaskRepository;
 import com.swipelab.tasks.application.port.out.TargetSpeciesProvider;
 import com.swipelab.integration.stardbi.StardbiSyncService;
+import com.swipelab.classification.infrastructure.ImageRepository;
+import com.swipelab.classification.infrastructure.ClassificationRepository;
+import com.swipelab.dto.response.TaskProgressResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -39,6 +42,8 @@ public class TaskService {
     private final TaskMapper taskMapper;
     private final StardbiSyncService stardbiSyncService;
     private final SecurityAuthorizationService securityAuthorizationService;
+    private final ImageRepository imageRepository;
+    private final ClassificationRepository classificationRepository;
 
 
     // =========================
@@ -180,7 +185,7 @@ public class TaskService {
                 .collect(Collectors.toList());
         }
         return tasks.stream()
-                .map(task -> taskMapper.toResponse(task, false))
+                .map(task -> taskMapper.toResponse(task, false, buildProgress(task.getId())))
                 .collect(Collectors.toList());
     }
 
@@ -188,7 +193,7 @@ public class TaskService {
     public TaskResponse getTaskDetailsResearcher(Long taskId, String username) {
         Task task = getTask(taskId);
         verifyTaskAccess(task, username);
-        return mapToResponse(task);
+        return taskMapper.toResponse(task, false, buildProgress(taskId));
     }
 
     @Transactional
@@ -280,13 +285,24 @@ public class TaskService {
     // Helpers
     // =========================
 
+    /**
+     * Computes real image progress for a task by querying the images and
+     * classifications tables. imagesClassified is a simple "touched" count
+     * (any classification exists) until the threshold-gated logic is built.
+     */
+    private TaskProgressResponse buildProgress(Long taskId) {
+        long total = imageRepository.countByTaskId(taskId);
+        long classified = classificationRepository.countDistinctImagesByTaskId(taskId);
+        return new TaskProgressResponse((int) total, (int) classified);
+    }
+
     private Task getTask(Long id) {
         return taskRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Task not found with id: " + id));
     }
 
     private TaskResponse mapToResponse(Task task) {
-        return taskMapper.toResponse(task, false);
+        return taskMapper.toResponse(task, false, buildProgress(task.getId()));
     }
 
     // Legacy support if needed, but preferably use new methods

--- a/backend/src/main/java/com/swipelab/tasks/domain/TaskMapper.java
+++ b/backend/src/main/java/com/swipelab/tasks/domain/TaskMapper.java
@@ -98,10 +98,14 @@ public class TaskMapper {
     // =========================
 
     public TaskResponse toResponse(Task task) {
-        return toResponse(task, false);
+        return toResponse(task, false, TaskProgressResponse.empty());
     }
 
     public TaskResponse toResponse(Task task, boolean assignedToUser) {
+        return toResponse(task, assignedToUser, TaskProgressResponse.empty());
+    }
+
+    public TaskResponse toResponse(Task task, boolean assignedToUser, TaskProgressResponse progress) {
         if (task == null) {
             return null;
         }
@@ -117,7 +121,7 @@ public class TaskMapper {
                 .sharedWithResearchers(task.getSharedWithResearchers())
                 .isPublic(task.getIsPublic())
                 .targetSpecies(targetSpeciesProvider.getSpeciesByIds(task.getTargetSpeciesIds()))
-                .progress(TaskProgressResponse.empty())
+                .progress(progress)
                 // New fields
                 .createdAt(task.getCreatedAt() != null
                         ? java.time.OffsetDateTime.of(task.getCreatedAt(), java.time.ZoneOffset.UTC)

--- a/backend/src/test/java/com/swipelab/tasks/application/TaskServiceTest.java
+++ b/backend/src/test/java/com/swipelab/tasks/application/TaskServiceTest.java
@@ -3,6 +3,7 @@ package com.swipelab.tasks.application;
 import com.swipelab.dto.request.CreateTaskRequest;
 import com.swipelab.dto.request.UpdateTaskRequest;
 import com.swipelab.dto.response.TaskPageResponse;
+import com.swipelab.dto.response.TaskProgressResponse;
 import com.swipelab.dto.response.TaskResponse;
 import com.swipelab.exception.DuplicateResourceException;
 import com.swipelab.exception.ResourceNotFoundException;
@@ -13,6 +14,8 @@ import com.swipelab.tasks.domain.Task;
 import com.swipelab.tasks.domain.TaskMapper;
 import com.swipelab.tasks.domain.TaskStatus;
 import com.swipelab.tasks.infrastructure.TaskRepository;
+import com.swipelab.classification.infrastructure.ImageRepository;
+import com.swipelab.classification.infrastructure.ClassificationRepository;
 import com.swipelab.classification.infrastructure.LabelRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -55,7 +58,11 @@ class TaskServiceTest {
     @Mock
     private com.swipelab.auth.application.SecurityAuthorizationService securityAuthorizationService;
 
+    @Mock
+    private ImageRepository imageRepository;
 
+    @Mock
+    private ClassificationRepository classificationRepository;
 
     @InjectMocks
     private TaskService taskService;
@@ -154,7 +161,9 @@ class TaskServiceTest {
     void getResearcherDashboard_ShouldReturnAllTasks() {
         when(securityAuthorizationService.isSuperAdmin(anyString())).thenReturn(true);
         when(taskRepository.findAll()).thenReturn(Collections.singletonList(task));
-        when(taskMapper.toResponse(task, false)).thenReturn(taskResponse);
+        when(imageRepository.countByTaskId(1L)).thenReturn(10L);
+        when(classificationRepository.countDistinctImagesByTaskId(1L)).thenReturn(6L);
+        when(taskMapper.toResponse(eq(task), eq(false), any(TaskProgressResponse.class))).thenReturn(taskResponse);
 
         List<TaskResponse> responses = taskService.getResearcherDashboard("superadmin");
 
@@ -166,12 +175,13 @@ class TaskServiceTest {
         CreateTaskRequest request = new CreateTaskRequest();
         request.setName("New Task");
         request.setDescription("Valid desc");
-        
-        when(taskRepository.existsByCreatedByAndName(anyString(), anyString())).thenReturn(false);
 
+        when(taskRepository.existsByCreatedByAndName(anyString(), anyString())).thenReturn(false);
         when(taskMapper.toEntity(request)).thenReturn(task);
         when(taskRepository.save(task)).thenReturn(task);
-        when(taskMapper.toResponse(task, false)).thenReturn(taskResponse);
+        when(imageRepository.countByTaskId(1L)).thenReturn(0L);
+        when(classificationRepository.countDistinctImagesByTaskId(1L)).thenReturn(0L);
+        when(taskMapper.toResponse(eq(task), eq(false), any(TaskProgressResponse.class))).thenReturn(taskResponse);
 
         TaskResponse response = taskService.createTask(request, "admin_mock", null, null);
 
@@ -197,7 +207,9 @@ class TaskServiceTest {
     void archiveTask_ShouldSetStatusArchived() {
         when(securityAuthorizationService.isSuperAdmin(anyString())).thenReturn(true);
         when(taskRepository.findById(1L)).thenReturn(Optional.of(task));
-        when(taskMapper.toResponse(task, false)).thenReturn(taskResponse);
+        when(imageRepository.countByTaskId(1L)).thenReturn(5L);
+        when(classificationRepository.countDistinctImagesByTaskId(1L)).thenReturn(3L);
+        when(taskMapper.toResponse(eq(task), eq(false), any(TaskProgressResponse.class))).thenReturn(taskResponse);
 
         taskService.archiveTask(1L, "superadmin");
 
@@ -209,7 +221,9 @@ class TaskServiceTest {
         task.setStatus(TaskStatus.PAUSED);
         when(securityAuthorizationService.isSuperAdmin(anyString())).thenReturn(true);
         when(taskRepository.findById(1L)).thenReturn(Optional.of(task));
-        when(taskMapper.toResponse(task, false)).thenReturn(taskResponse);
+        when(imageRepository.countByTaskId(1L)).thenReturn(5L);
+        when(classificationRepository.countDistinctImagesByTaskId(1L)).thenReturn(2L);
+        when(taskMapper.toResponse(eq(task), eq(false), any(TaskProgressResponse.class))).thenReturn(taskResponse);
 
         taskService.activateTask(1L, "superadmin");
 
@@ -220,7 +234,9 @@ class TaskServiceTest {
     void pauseTask_ShouldSetStatusPaused() {
         when(securityAuthorizationService.isSuperAdmin(anyString())).thenReturn(true);
         when(taskRepository.findById(1L)).thenReturn(Optional.of(task));
-        when(taskMapper.toResponse(task, false)).thenReturn(taskResponse);
+        when(imageRepository.countByTaskId(1L)).thenReturn(5L);
+        when(classificationRepository.countDistinctImagesByTaskId(1L)).thenReturn(1L);
+        when(taskMapper.toResponse(eq(task), eq(false), any(TaskProgressResponse.class))).thenReturn(taskResponse);
 
         taskService.pauseTask(1L, "superadmin");
 
@@ -232,7 +248,9 @@ class TaskServiceTest {
         when(securityAuthorizationService.isSuperAdmin(anyString())).thenReturn(true);
         when(taskRepository.findById(1L)).thenReturn(Optional.of(task));
         UpdateTaskRequest request = new UpdateTaskRequest();
-        when(taskMapper.toResponse(task, false)).thenReturn(taskResponse);
+        when(imageRepository.countByTaskId(1L)).thenReturn(5L);
+        when(classificationRepository.countDistinctImagesByTaskId(1L)).thenReturn(0L);
+        when(taskMapper.toResponse(eq(task), eq(false), any(TaskProgressResponse.class))).thenReturn(taskResponse);
 
         taskService.updateTask(1L, request, "superadmin");
 
@@ -288,5 +306,53 @@ class TaskServiceTest {
 
         assertNotNull(response);
         assertTrue(task.getAssignedUsernames().contains("testuser"));
+    }
+
+    // ===================================================
+    // buildProgress — image count correctness
+    // ===================================================
+
+    @Test
+    void getResearcherDashboard_ShouldReflectRealImageCounts_WhenImagesExist() {
+        // Happy flow: task has 10 images, 6 have been classified
+        when(securityAuthorizationService.isSuperAdmin(anyString())).thenReturn(true);
+        when(taskRepository.findAll()).thenReturn(Collections.singletonList(task));
+        when(imageRepository.countByTaskId(1L)).thenReturn(10L);
+        when(classificationRepository.countDistinctImagesByTaskId(1L)).thenReturn(6L);
+
+        TaskProgressResponse[] captured = new TaskProgressResponse[1];
+        when(taskMapper.toResponse(eq(task), eq(false), any(TaskProgressResponse.class)))
+                .thenAnswer(inv -> {
+                    captured[0] = inv.getArgument(2);
+                    return taskResponse;
+                });
+
+        taskService.getResearcherDashboard("superadmin");
+
+        assertNotNull(captured[0]);
+        assertEquals(10, captured[0].getTotalImages(),   "totalImages should be 10");
+        assertEquals(6,  captured[0].getImagesClassified(), "imagesClassified should be 6");
+    }
+
+    @Test
+    void getResearcherDashboard_ShouldReturnZeroProgress_WhenNoImagesExist() {
+        // Edge case: brand-new task with no images synced yet
+        when(securityAuthorizationService.isSuperAdmin(anyString())).thenReturn(true);
+        when(taskRepository.findAll()).thenReturn(Collections.singletonList(task));
+        when(imageRepository.countByTaskId(1L)).thenReturn(0L);
+        when(classificationRepository.countDistinctImagesByTaskId(1L)).thenReturn(0L);
+
+        TaskProgressResponse[] captured = new TaskProgressResponse[1];
+        when(taskMapper.toResponse(eq(task), eq(false), any(TaskProgressResponse.class)))
+                .thenAnswer(inv -> {
+                    captured[0] = inv.getArgument(2);
+                    return taskResponse;
+                });
+
+        taskService.getResearcherDashboard("superadmin");
+
+        assertNotNull(captured[0]);
+        assertEquals(0, captured[0].getTotalImages(),    "totalImages should be 0 for empty task");
+        assertEquals(0, captured[0].getImagesClassified(), "imagesClassified should be 0 for empty task");
     }
 }


### PR DESCRIPTION
### What was done
This PR fixes a bug where the total number of images and the classified images count always displayed as "0 of 0" in the `TasksManagementScreen`. The root cause was a hardcoded `TaskProgressResponse.empty()` object in `TaskMapper`.

- Added `countByTaskId` to `ImageRepository`.
- Added `countDistinctImagesByTaskId` to `ClassificationRepository`.
- Refactored `TaskMapper` to accept dynamic progress counts.
- Updated `TaskService` to query real progress data and inject it into the API response for all dashboard and task mutation endpoints.
- Updated `TaskServiceTest` (all 383 backend tests pass).

### Note on "Classified" Threshold
Currently, the `imagesClassified` number counts any unique image that has received **at least one classification** (a simple "touched" or "in-progress" metric). 

**Future Change Required:**
Once the backend logic for `minClassificationsPerImage` (consensus threshold) is fully implemented, we will need to update the JPQL query in `ClassificationRepository.java`. To accurately measure true completion, the query should be updated to use a `HAVING` clause, ensuring an image is only counted as "classified" if it has met the threshold requirement. Example future query:
```sql
SELECT COUNT(DISTINCT c.image.id) FROM Classification c 
WHERE c.taskId = :taskId 
GROUP BY c.image.id 
HAVING COUNT(c.id) >= :minClassifications