### PR TITLE
feat(frontend): Comprehensive Gamification and UI Overhaul across User Screens

### DIFF
--- a/frontend/app/components/RegisterForm.tsx
+++ b/frontend/app/components/RegisterForm.tsx
@@ -8,6 +8,7 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
+import { Ionicons } from '@expo/vector-icons';
 import { apiFetch } from "../api/apiFetch";
 import { useAuthStore } from "../stores/authStore";
 import { useModeStore } from "../stores/modeStore";
@@ -102,6 +103,10 @@ export default function RegisterForm({ onClose }: Props) {
   return (
     <View style={styles.overlay}>
       <View style={styles.container}>
+        <TouchableOpacity style={styles.closeButton} onPress={onClose}>
+          <Ionicons name="close" size={24} color="#000000" />
+        </TouchableOpacity>
+
         {!success ? (
           <>
             <Text style={styles.title}>Register</Text>
@@ -111,7 +116,7 @@ export default function RegisterForm({ onClose }: Props) {
               value={username}
               onChangeText={setUsername}
               style={styles.input}
-              placeholderTextColor="#888"
+              placeholderTextColor="#333"
             />
             <TextInput
               placeholder="Email address"
@@ -120,14 +125,14 @@ export default function RegisterForm({ onClose }: Props) {
               style={styles.input}
               keyboardType="email-address"
               autoCapitalize="none"
-              placeholderTextColor="#888"
+              placeholderTextColor="#333"
             />
             <TextInput
               placeholder="Display Name (e.g., John Doe)"
               value={displayName}
               onChangeText={setDisplayName}
               style={styles.input}
-              placeholderTextColor="#888"
+              placeholderTextColor="#333"
             />
             <TextInput
               placeholder="Create a strong password"
@@ -135,9 +140,9 @@ export default function RegisterForm({ onClose }: Props) {
               onChangeText={setPassword}
               style={styles.input}
               secureTextEntry
-              placeholderTextColor="#888"
+              placeholderTextColor="#333"
             />
-            <Text style={{ fontSize: 12, color: "#666", marginBottom: 12, marginTop: -8, marginLeft: 4 }}>
+            <Text style={{ fontSize: 13, color: "#000", marginBottom: 16, marginTop: -6, marginLeft: 4 }}>
               Must be at least 8 chars, include an uppercase, a lowercase, a number, a special symbol, and no spaces.
             </Text>
             
@@ -147,7 +152,7 @@ export default function RegisterForm({ onClose }: Props) {
               onChangeText={setConfirmPassword}
               style={styles.input}
               secureTextEntry
-              placeholderTextColor="#888"
+              placeholderTextColor="#333"
             />
 
             {error ? <Text style={styles.error}>{error}</Text> : null}
@@ -162,10 +167,6 @@ export default function RegisterForm({ onClose }: Props) {
               ) : (
                 <Text style={styles.registerText}>Register</Text>
               )}
-            </TouchableOpacity>
-
-            <TouchableOpacity onPress={onClose} style={{ marginTop: 10 }}>
-              <Text style={styles.cancelText}>Cancel</Text>
             </TouchableOpacity>
           </>
         ) : (
@@ -192,36 +193,48 @@ export default function RegisterForm({ onClose }: Props) {
 const styles = StyleSheet.create({
   overlay: {
     ...StyleSheet.absoluteFillObject,
-    backgroundColor: "rgba(255,255,255,0.25)", // 75% opacity white behind
+    backgroundColor: "rgba(0,0,0,0.6)",
     justifyContent: "center",
     alignItems: "center",
+    zIndex: 1000,
   },
   container: {
-    width: "85%",
+    width: "90%",
+    maxWidth: 550,
     backgroundColor: "#fff",
-    borderRadius: 20,
-    padding: 20,
+    borderRadius: 24,
+    paddingHorizontal: 24,
+    paddingTop: 36,
+    paddingBottom: 24,
     shadowColor: "#000",
-    shadowOpacity: 0.2,
-    shadowRadius: 10,
-    elevation: 5,
+    shadowOpacity: 0.3,
+    shadowRadius: 15,
+    elevation: 8,
+    position: 'relative',
   },
-  title: { fontSize: 24, fontWeight: "bold", marginBottom: 12, textAlign: "center" },
+  closeButton: {
+    position: 'absolute',
+    top: 16,
+    right: 16,
+    zIndex: 10,
+    padding: 4,
+  },
+  title: { fontSize: 28, fontWeight: "900", marginBottom: 24, textAlign: "center", color: "#000000" },
   input: {
-    borderWidth: 1,
-    borderColor: "#ccc",
-    padding: 10,
-    borderRadius: 8,
-    marginBottom: 12,
+    backgroundColor: "#f3f4f6", // Soft grey background
+    padding: 14,
+    borderRadius: 12,
+    marginBottom: 16,
     fontSize: 16,
+    color: "#000000", // Darker text
   },
   registerButton: {
     backgroundColor: "#4B7BE5",
-    padding: 12,
+    padding: 14,
     borderRadius: 12,
     alignItems: "center",
+    marginTop: 8,
   },
-  registerText: { color: "#fff", fontWeight: "600", fontSize: 16 },
-  error: { color: "red", marginBottom: 8, textAlign: "center" },
-  cancelText: { color: "#4B7BE5", textAlign: "center", marginTop: 5 },
+  registerText: { color: "#fff", fontWeight: "bold", fontSize: 18 },
+  error: { color: "red", marginBottom: 12, textAlign: "center", fontWeight: "500" },
 });

--- a/frontend/app/components/user/TaskCard.tsx
+++ b/frontend/app/components/user/TaskCard.tsx
@@ -143,10 +143,12 @@ const styles = StyleSheet.create({
     },
     title: {
         fontSize: 17,
-        fontWeight: '800',
+        fontWeight: '900',
         flex: 1,
         marginRight: 8,
         lineHeight: 22,
+        textTransform: 'uppercase',
+        letterSpacing: 0.5,
     },
     description: {
         fontSize: 13,

--- a/frontend/app/components/user/UserTopBar.tsx
+++ b/frontend/app/components/user/UserTopBar.tsx
@@ -71,10 +71,11 @@ export default function UserTopBar({
         </View>
       </TouchableOpacity>
 
-      <TouchableOpacity style={[styles.statsBlock, isPhone && { paddingHorizontal: 12, height: 60, flexShrink: 1, marginHorizontal: 8 }]} onPress={() => navigation.navigate("Challenges")}>
+      <TouchableOpacity style={[styles.statsBlock, isPhone && { paddingHorizontal: 12, paddingVertical: 10, flexShrink: 1, marginHorizontal: 8 }]} onPress={() => navigation.navigate("Challenges")}>
         <Text style={[styles.statsText, isPhone && { fontSize: 11 }]} numberOfLines={1}>Score: {formattedScore}</Text>
         <Text style={[styles.statsText, isPhone && { fontSize: 11 }]} numberOfLines={1}>Rank: {displayRank}</Text>
         {!isPhone && <Text style={styles.statsText}>{displayStreak} days streak</Text>}
+        <Text style={[styles.statsText, { fontSize: 10, opacity: 0.85, marginTop: 4, fontStyle: 'italic' }]}>Move to Challenges ▸</Text>
       </TouchableOpacity>
 
       <View style={styles.rightSection}>
@@ -112,8 +113,8 @@ const styles = StyleSheet.create({
   username: { fontSize: 12, fontWeight: '600' },
   statsBlock: {
     backgroundColor: '#4B7BE5',
-    paddingHorizontal: 20, paddingVertical: 8,
-    borderRadius: 12, alignItems: 'center', justifyContent: 'center', height: 70,
+    paddingHorizontal: 20, paddingVertical: 10,
+    borderRadius: 12, alignItems: 'center', justifyContent: 'center',
   },
   statsText: { color: '#fff', fontSize: 12, fontWeight: '600', lineHeight: 18 },
   rightSection: { flexDirection: 'row', alignItems: 'center' },

--- a/frontend/app/components/user/UserTopBar.tsx
+++ b/frontend/app/components/user/UserTopBar.tsx
@@ -71,11 +71,10 @@ export default function UserTopBar({
         </View>
       </TouchableOpacity>
 
-      <TouchableOpacity style={[styles.statsBlock, isPhone && { paddingHorizontal: 12, paddingVertical: 10, flexShrink: 1, marginHorizontal: 8 }]} onPress={() => navigation.navigate("Challenges")}>
+      <TouchableOpacity style={[styles.statsBlock, isPhone && { paddingHorizontal: 12, height: 60, flexShrink: 1, marginHorizontal: 8 }]} onPress={() => navigation.navigate("Challenges")}>
         <Text style={[styles.statsText, isPhone && { fontSize: 11 }]} numberOfLines={1}>Score: {formattedScore}</Text>
         <Text style={[styles.statsText, isPhone && { fontSize: 11 }]} numberOfLines={1}>Rank: {displayRank}</Text>
         {!isPhone && <Text style={styles.statsText}>{displayStreak} days streak</Text>}
-        <Text style={[styles.statsText, { fontSize: 10, opacity: 0.85, marginTop: 4, fontStyle: 'italic' }]}>Move to Challenges ▸</Text>
       </TouchableOpacity>
 
       <View style={styles.rightSection}>
@@ -113,8 +112,8 @@ const styles = StyleSheet.create({
   username: { fontSize: 12, fontWeight: '600' },
   statsBlock: {
     backgroundColor: '#4B7BE5',
-    paddingHorizontal: 20, paddingVertical: 10,
-    borderRadius: 12, alignItems: 'center', justifyContent: 'center',
+    paddingHorizontal: 20, paddingVertical: 8,
+    borderRadius: 12, alignItems: 'center', justifyContent: 'center', height: 70,
   },
   statsText: { color: '#fff', fontSize: 12, fontWeight: '600', lineHeight: 18 },
   rightSection: { flexDirection: 'row', alignItems: 'center' },

--- a/frontend/app/screens/user/ChallengesScreen.tsx
+++ b/frontend/app/screens/user/ChallengesScreen.tsx
@@ -31,18 +31,40 @@ interface ChallengeDto {
     } | null;
 }
 
-function ChallengeCard({ challenge }: { challenge: ChallengeDto }) {
+const CARD_COLORS = [
+    '#FFD700', // Gamified Gold/Yellow
+    '#00FA9A', // Vibrant Spring Green
+    '#00BFFF', // Deep Sky Blue
+    '#FF69B4', // Hot Pink
+    '#FFA500', // Bright Orange
+    '#ADFF2F', // Electric Lime
+];
+
+function ChallengeCard({ challenge, index }: { challenge: ChallengeDto, index: number }) {
     const progressPercent = Math.min(100, Math.max(0, (challenge.progress / challenge.target) * 100));
+    const bgColor = CARD_COLORS[index % CARD_COLORS.length];
 
     return (
-        <View style={[styles.card, { backgroundColor: '#fff' }]}>
+        <View style={[styles.card, { backgroundColor: bgColor }]}>
             {/* Header Row: Title */}
             <Text style={styles.cardTitle}>{challenge.name}</Text>
 
             {/* Description */}
             <Text style={styles.cardDesc}>{challenge.description}</Text>
 
-            {/* Content Row: Progress & Icon */}
+            {/* Reward/Icon Container */}
+            <View style={styles.iconContainer}>
+                {challenge.badge?.iconUrl ? (
+                     <Image 
+                        source={{ uri: challenge.badge.iconUrl }}
+                        style={{ width: 48, height: 48, resizeMode: 'contain' }}
+                     />
+                ) : (
+                     <Text style={styles.iconText}>🏆</Text>
+                )}
+            </View>
+
+            {/* Content Row: Progress */}
             <View style={styles.cardContent}>
                 <View style={styles.progressSection}>
                     <Text style={styles.progressText}>
@@ -60,18 +82,6 @@ function ChallengeCard({ challenge }: { challenge: ChallengeDto }) {
                             ]}
                         />
                     </View>
-                </View>
-
-                {/* Reward/Icon Container */}
-                <View style={styles.iconContainer}>
-                    {challenge.badge?.iconUrl ? (
-                         <Image 
-                            source={{ uri: challenge.badge.iconUrl }}
-                            style={{ width: 48, height: 48, resizeMode: 'contain' }}
-                         />
-                    ) : (
-                         <Text style={styles.iconText}>🏆</Text>
-                    )}
                 </View>
             </View>
         </View>
@@ -102,9 +112,6 @@ export default function ChallengesScreen() {
         <ScreenHeaderLayout
             leftIcon={require('../../../assets/images/challenges.png')}
             leftTitle="Challenges"
-            centerIcon={require('../../../assets/images/leaderboard.png')}
-            centerTitle="Leaderboard"
-            onCenterPress={() => navigation.navigate('Leaderboard')}
             rightIcon={<Ionicons name="play" size={28} color={themeColors.text} />}
             rightTitle="Play"
             onRightPress={() => navigation.navigate('SwipeLab')}
@@ -120,14 +127,14 @@ export default function ChallengesScreen() {
 
                 {/* In Progress Section */}
                 <Text style={[styles.sectionHeader, { color: themeColors.text }]}>In Progress</Text>
-                {challenges.filter((c: ChallengeDto) => !c.completed).map((challenge: ChallengeDto) => (
-                    <ChallengeCard key={challenge.challengeId} challenge={challenge} />
+                {challenges.filter((c: ChallengeDto) => !c.completed).map((challenge: ChallengeDto, index: number) => (
+                    <ChallengeCard key={challenge.challengeId} challenge={challenge} index={index} />
                 ))}
 
                 {/* Completed Section */}
                 <Text style={[styles.sectionHeader, { color: themeColors.text }]}>Completed</Text>
-                {challenges.filter((c: ChallengeDto) => c.completed).map((challenge: ChallengeDto) => (
-                    <ChallengeCard key={challenge.challengeId} challenge={challenge} />
+                {challenges.filter((c: ChallengeDto) => c.completed).map((challenge: ChallengeDto, index: number) => (
+                    <ChallengeCard key={challenge.challengeId} challenge={challenge} index={index} />
                 ))}
 
                 <View style={{ height: 40 }} />
@@ -177,62 +184,63 @@ const styles = StyleSheet.create({
     },
     card: {
         borderRadius: 16,
-        padding: 16,
+        padding: 20,
         marginBottom: 16,
         // Shadow
         shadowColor: '#000',
-        shadowOffset: { width: 0, height: 2 },
-        shadowOpacity: 0.1,
-        shadowRadius: 4,
-        elevation: 3,
-        borderWidth: 1,
-        borderColor: 'rgba(0,0,0,0.05)',
+        shadowOffset: { width: 0, height: 4 },
+        shadowOpacity: 0.2,
+        shadowRadius: 8,
+        elevation: 5,
     },
     cardTitle: {
-        fontSize: 18,
-        fontWeight: 'bold',
-        color: '#000',
-        marginBottom: 4,
+        fontSize: 20,
+        fontWeight: '900',
+        color: '#1a1a2e',
+        marginBottom: 8,
         textAlign: 'center',
+        letterSpacing: 0.5,
+        textTransform: 'uppercase',
     },
     cardDesc: {
-        fontSize: 14,
-        color: '#333',
+        fontSize: 15,
+        color: '#333333',
+        marginBottom: 16,
+        lineHeight: 22,
         textAlign: 'center',
-        marginBottom: 12,
     },
     cardContent: {
-        flexDirection: 'row',
-        alignItems: 'flex-end',
-        justifyContent: 'space-between',
+        alignItems: 'center',
+        width: '100%',
     },
     progressSection: {
-        flex: 1,
-        marginRight: 16,
+        width: '100%',
+        alignItems: 'center',
     },
     progressText: {
-        fontSize: 12,
-        color: '#444',
-        marginBottom: 2,
+        fontSize: 13,
+        color: '#1a1a2e',
+        marginBottom: 4,
+        fontWeight: '700',
+        textAlign: 'center',
     },
     progressBarTrack: {
-        height: 8,
-        backgroundColor: 'rgba(255,255,255,0.5)', // Semi-transparent white
-        borderRadius: 4,
-        marginTop: 6,
+        height: 10,
+        width: '80%',
+        backgroundColor: 'rgba(0,0,0,0.1)', // Subtle dark track
+        borderRadius: 5,
+        marginTop: 8,
         overflow: 'hidden',
-        borderWidth: 0.5,
-        borderColor: 'rgba(0,0,0,0.1)',
     },
     progressBarFill: {
         height: '100%',
-        backgroundColor: '#4B7BE5', // Default fill, maybe override?
-        borderRadius: 4,
+        backgroundColor: '#1a1a2e', // Dark fill for contrast
+        borderRadius: 5,
     },
     iconContainer: {
         justifyContent: 'center',
         alignItems: 'center',
-
+        marginBottom: 16,
     },
     iconText: {
         fontSize: 32,

--- a/frontend/app/screens/user/LeaderboardScreen.tsx
+++ b/frontend/app/screens/user/LeaderboardScreen.tsx
@@ -35,25 +35,12 @@ const getMedalEmoji = (rank: number): string => {
 };
 
 const getRowStyle = (rank: number, type: 'allTime' | 'monthly', themeColors: any, isDark: boolean) => {
-    // Relaxed Pastel Colors
-    // Rank 1: Soft Gold
-    // Rank 2: Soft Silver/Gray
-    // Rank 3: Soft Bronze/Orange
-    // Rank 4+: Default/Transparent
+    let bgColor = isDark ? themeColors.card : '#ffffff'; // Default
 
-    // Light Mode Pastels
-    const lightColors = ['#FFF9C4', '#F5F5F5', '#FFCCBC'];
-    // Dark Mode Muted Colors (Darker pastels so text is readable)
-    const darkColors = ['#5D4037', '#424242', '#3E2723']; // Just examples, better to use semi-transparent
-
-    // Better approach: Use opacity on base colors?
-    // Let's use relaxed solid colors that work for both or switch based on theme
-
-    let bgColor = isDark ? themeColors.card : '#fff'; // Default
-
-    if (rank === 1) bgColor = isDark ? '#4A3B00' : '#FFF59D'; // Gold-ish
-    else if (rank === 2) bgColor = isDark ? '#37474F' : '#CFD8DC'; // Silver-ish
-    else if (rank === 3) bgColor = isDark ? '#3E2723' : '#FFAB91'; // Bronze-ish
+    // Vibrant medal colors for top 3
+    if (rank === 1) bgColor = isDark ? '#B8860B' : '#FFD700'; // Vibrant Gold
+    else if (rank === 2) bgColor = isDark ? '#4169E1' : '#AEE2FF'; // Frosty Blue (replacing grey/silver)
+    else if (rank === 3) bgColor = isDark ? '#A0522D' : '#F4A460'; // Rich Bronze
 
     return { backgroundColor: bgColor };
 };
@@ -67,8 +54,10 @@ interface LeaderboardTableProps {
 function LeaderboardTable({ title, data, type }: LeaderboardTableProps) {
     const { theme } = useThemeStore();
     const themeColors = Colors[theme as keyof typeof Colors];
-    const headerBg = theme === 'dark' ? themeColors.card : '#e0e0e0';
-    const cellColor = theme === 'dark' ? themeColors.text : '#333';
+    // Use a vibrant primary color for the header
+    const headerBg = theme === 'dark' ? '#312E81' : '#4B7BE5'; // Indigo in dark, Blue in light
+    const headerTextColor = '#ffffff'; 
+    const cellColor = theme === 'dark' ? themeColors.text : '#2d3748'; // Richer dark gray for text in light mode
 
     return (
         <View style={styles.tableContainer}>
@@ -76,27 +65,32 @@ function LeaderboardTable({ title, data, type }: LeaderboardTableProps) {
             <View style={[styles.table, { backgroundColor: themeColors.card }]}>
                 {/* Header Row */}
                 <View style={[styles.headerRow, { backgroundColor: headerBg }]}>
-                    <Text style={[styles.headerCell, styles.rankCol, { color: cellColor }]}>Rank</Text>
-                    <Text style={[styles.headerCell, styles.userCol, { color: cellColor }]}>User</Text>
-                    <Text style={[styles.headerCell, styles.scoreCol, { color: cellColor }]}>Score</Text>
+                    <Text style={[styles.headerCell, styles.rankCol, { color: headerTextColor }]}>Rank</Text>
+                    <Text style={[styles.headerCell, styles.userCol, { color: headerTextColor }]}>User</Text>
+                    <Text style={[styles.headerCell, styles.scoreCol, { color: headerTextColor }]}>Score</Text>
                 </View>
 
                 {/* Data Rows */}
-                {data.map((entry) => (
-                    <View
-                        key={entry.rank}
-                        style={[styles.dataRow, getRowStyle(entry.rank, type, themeColors, theme === 'dark'), { borderBottomColor: themeColors.border }]}
-                    >
-                        <Text style={[styles.dataCell, styles.rankCol, { color: cellColor }]}>{entry.rank}</Text>
-                        <Text style={[styles.dataCell, styles.userCol, { color: cellColor }]}>{entry.username}</Text>
-                        <View style={styles.scoreContainer}>
-                            <Text style={[styles.dataCell, styles.scoreText, { color: cellColor }]}>
-                                {entry.score.toLocaleString()}
-                            </Text>
-                            <Text style={styles.medal}>{getMedalEmoji(entry.rank)}</Text>
+                {data.map((entry) => {
+                    const isTop3 = entry.rank <= 3;
+                    // For top 3, make text color slightly darker in light mode for better contrast
+                    const rowTextColor = (isTop3 && theme !== 'dark') ? '#1a202c' : cellColor;
+                    return (
+                        <View
+                            key={entry.rank}
+                            style={[styles.dataRow, getRowStyle(entry.rank, type, themeColors, theme === 'dark'), { borderBottomColor: themeColors.border }]}
+                        >
+                            <Text style={[styles.dataCell, styles.rankCol, { color: rowTextColor, fontWeight: 'bold' }]}>{entry.rank}</Text>
+                            <Text style={[styles.dataCell, styles.userCol, { color: rowTextColor, fontWeight: '700' }]}>{entry.username}</Text>
+                            <View style={styles.scoreContainer}>
+                                <Text style={[styles.dataCell, styles.scoreText, { color: rowTextColor, fontWeight: 'bold' }]}>
+                                    {entry.score.toLocaleString()}
+                                </Text>
+                                <Text style={styles.medal}>{getMedalEmoji(entry.rank)}</Text>
+                            </View>
                         </View>
-                    </View>
-                ))}
+                    );
+                })}
             </View>
         </View>
     );
@@ -104,7 +98,7 @@ function LeaderboardTable({ title, data, type }: LeaderboardTableProps) {
 
 
 const RANK_COLORS: Record<string, string> = {
-    UNRANKED: '#9ca3af',
+    UNRANKED: '#818CF8', // Indigo instead of grey
     BEGINNER: '#60a5fa',
     EXPERT: '#34d399',
     PRO: '#a78bfa',
@@ -235,11 +229,8 @@ export default function LeaderboardScreen() {
 
     return (
         <ScreenHeaderLayout
-            leftIcon={require('../../../assets/images/challenges.png')}
-            leftTitle="Challenges"
-            onLeftPress={() => navigation.navigate('Challenges')}
-            centerIcon={require('../../../assets/images/leaderboard.png')}
-            centerTitle="Leaderboard"
+            leftIcon={require('../../../assets/images/leaderboard.png')}
+            leftTitle="Leaderboard"
             rightIcon={require('../../../assets/images/profile.png')}
             rightTitle={data ? `Your Spot: #${data.currentUser.rank}` : 'Your Spot: -'}
             contentContainerStyle={{ padding: 0 }}
@@ -278,14 +269,14 @@ export default function LeaderboardScreen() {
 
                 {/* All Time Leaderboard */}
                 <LeaderboardTable
-                    title="Greatest Of All Time"
+                    title="🏆 Greatest Of All Time"
                     data={data.allTime}
                     type="allTime"
                 />
 
                 {/* Monthly Leaderboard */}
                 <LeaderboardTable
-                    title="Greatest Of The Month"
+                    title="🔥 Greatest Of The Month"
                     data={data.monthly}
                     type="monthly"
                 />
@@ -340,46 +331,49 @@ const styles = StyleSheet.create({
     },
     tableTitle: {
         fontSize: 22,
-        fontWeight: 'bold',
-        fontStyle: 'italic',
+        fontWeight: '900',
         color: '#1a1a2e',
         marginBottom: 12,
         textAlign: 'center',
+        letterSpacing: 0.5,
+        textTransform: 'uppercase',
     },
     table: {
-        borderRadius: 12,
+        borderRadius: 16,
         overflow: 'hidden',
         backgroundColor: '#fff',
-        shadowColor: '#000',
-        shadowOffset: { width: 0, height: 2 },
-        shadowOpacity: 0.1,
-        shadowRadius: 4,
-        elevation: 3,
+        shadowColor: '#4B7BE5',
+        shadowOffset: { width: 0, height: 6 },
+        shadowOpacity: 0.15,
+        shadowRadius: 8,
+        elevation: 5,
+        borderWidth: 1,
+        borderColor: 'rgba(75, 123, 229, 0.1)',
     },
     headerRow: {
         flexDirection: 'row',
-        backgroundColor: '#e0e0e0',
-        paddingVertical: 10,
+        backgroundColor: '#4B7BE5',
+        paddingVertical: 14,
         paddingHorizontal: 8,
-        borderBottomWidth: 2,
-        borderBottomColor: '#ccc',
     },
     headerCell: {
-        fontWeight: 'bold',
-        fontSize: 14,
-        color: '#333',
+        fontWeight: '800',
+        fontSize: 15,
+        color: '#fff',
         textAlign: 'center',
+        letterSpacing: 0.5,
+        textTransform: 'uppercase',
     },
     dataRow: {
         flexDirection: 'row',
-        paddingVertical: 12,
+        paddingVertical: 14,
         paddingHorizontal: 8,
         borderBottomWidth: 1,
-        borderBottomColor: 'rgba(255,255,255,0.3)',
+        borderBottomColor: 'rgba(0,0,0,0.05)',
+        alignItems: 'center',
     },
     dataCell: {
-        fontSize: 14,
-        fontWeight: '600',
+        fontSize: 15,
         textAlign: 'center',
     },
     rankCol: {

--- a/frontend/app/screens/user/StatsScreen.tsx
+++ b/frontend/app/screens/user/StatsScreen.tsx
@@ -84,14 +84,21 @@ function ProgressBar({ value, color, label, maxValue = 1 }: { value: number; col
     );
 }
 
-function SummaryCard({ title, value, subtext }: { title: string; value: string | number; subtext?: string }) {
+function SummaryCard({ title, value, subtext, icon }: { title: string; value: string | number; subtext?: string, icon?: string }) {
     const { theme } = useThemeStore();
     const themeColors = Colors[theme as keyof typeof Colors];
     return (
         <View style={[styles.summaryCard, { backgroundColor: themeColors.card }]}>
-            <Text style={[styles.cardTitle, { color: themeColors.textSecondary }]}>{title}</Text>
+            <View style={styles.cardHeader}>
+                <Text style={[styles.cardTitle, { color: themeColors.textSecondary }]}>{title}</Text>
+                {icon && <Text style={styles.cardIcon}>{icon}</Text>}
+            </View>
             <Text style={[styles.cardValue, { color: themeColors.text }]}>{value}</Text>
-            {subtext && <Text style={styles.cardSubtext}>{subtext}</Text>}
+            {subtext && (
+                <View style={styles.badgeContainer}>
+                    <Text style={styles.badgeText}>{subtext}</Text>
+                </View>
+            )}
         </View>
     );
 }
@@ -140,10 +147,10 @@ export default function StatsScreen() {
 
                 {/* User Profile Summary */}
                 <View style={styles.grid}>
-                    <SummaryCard title="Global Rank" value={`#${data.summary?.summary?.rank?.allTime ?? '-'}`} subtext="Top 1%" />
-                    <SummaryCard title="Score" value={data.userInfo?.score?.toLocaleString() ?? '0'} />
-                    <SummaryCard title="Tasks Done" value={data.summary?.summary?.totalClassifications ?? 0} />
-                    <SummaryCard title="Accuracy" value={`${((data.summary?.summary?.accuracy ?? 0) * 100).toFixed(1)}%`} subtext="Overall" />
+                    <SummaryCard title="Global Rank" value={`#${data.summary?.summary?.rank?.allTime ?? '-'}`} subtext="Top 1%" icon="🌍" />
+                    <SummaryCard title="Score" value={data.userInfo?.score?.toLocaleString() ?? '0'} icon="🌟" />
+                    <SummaryCard title="Tasks Done" value={data.summary?.summary?.totalClassifications ?? 0} icon="✅" />
+                    <SummaryCard title="Accuracy" value={`${((data.summary?.summary?.accuracy ?? 0) * 100).toFixed(1)}%`} subtext="Overall" icon="🎯" />
                 </View>
 
                 {/* Streak */}
@@ -258,38 +265,61 @@ const styles = StyleSheet.create({
     summaryCard: {
         width: '48%',
         backgroundColor: '#fff',
-        padding: 16,
-        borderRadius: 12,
-        marginBottom: 12,
+        padding: 20,
+        borderRadius: 16,
+        marginBottom: 16,
         shadowColor: '#000',
-        shadowOffset: { width: 0, height: 2 },
-        shadowOpacity: 0.05,
-        shadowRadius: 4,
-        elevation: 2,
+        shadowOffset: { width: 0, height: 4 },
+        shadowOpacity: 0.08,
+        shadowRadius: 8,
+        elevation: 4,
+        borderWidth: 1,
+        borderColor: '#f0f0f0',
+    },
+    cardHeader: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        marginBottom: 12,
+    },
+    cardIcon: {
+        fontSize: 20,
     },
     cardTitle: {
         fontSize: 14,
+        fontWeight: '600',
         color: '#666',
-        marginBottom: 8,
+        textTransform: 'uppercase',
+        letterSpacing: 0.5,
     },
     cardValue: {
-        fontSize: 24,
-        fontWeight: 'bold',
+        fontSize: 32,
+        fontWeight: '900',
         color: '#1a1a2e',
     },
-    cardSubtext: {
+    badgeContainer: {
+        marginTop: 8,
+        alignSelf: 'flex-start',
+        backgroundColor: '#e8f5e9', // Light green
+        paddingHorizontal: 10,
+        paddingVertical: 4,
+        borderRadius: 12,
+    },
+    badgeText: {
         fontSize: 12,
-        color: '#4B7BE5',
-        marginTop: 4,
+        fontWeight: 'bold',
+        color: '#2e7d32', // Dark green
     },
     section: {
         marginBottom: 24,
     },
     sectionTitle: {
         fontSize: 20,
-        fontWeight: 'bold',
+        fontWeight: '900',
         color: '#1a1a2e',
         marginBottom: 12,
+        textTransform: 'uppercase',
+        letterSpacing: 0.5,
     },
     card: {
         backgroundColor: '#fff',

--- a/frontend/app/screens/user/UserMyTasksScreen.tsx
+++ b/frontend/app/screens/user/UserMyTasksScreen.tsx
@@ -258,8 +258,10 @@ const styles = StyleSheet.create({
         marginTop: 8,
     },
     sectionTitle: {
-        fontSize: 16,
-        fontWeight: '700',
+        fontSize: 18,
+        fontWeight: '900',
+        textTransform: 'uppercase',
+        letterSpacing: 0.5,
     },
     // Empty state
     emptyCard: {


### PR DESCRIPTION
- Leaderboard & Challenges: Replaced pale colors with a highly saturated "arcade" palette, updated typography to be extra-bold and uppercase, and fixed a header navigation bug.
- Stats & My Tasks: Transformed plain summary cards into rewarding badges featuring emojis, massive value text, and styled subtext pills. Aligned the typography of task cards and section headers.
- Register Form: Upgraded the form to a modern modal with rounded corners, a dark backdrop to prevent visual bleeding from the login screen, and a cleaner close button layout.