### PR TITLE
fixed cache bug

### DIFF
--- a/frontend/app/screens/researcher/UsersManagementScreen.tsx
+++ b/frontend/app/screens/researcher/UsersManagementScreen.tsx
@@ -10,6 +10,7 @@ import {
     TextInput,
     TouchableOpacity,
     View,
+    Alert,
 } from 'react-native';
 import useResponsive from '../../hooks/useResponsive';
 import { Colors } from '../../../constants/theme';
@@ -31,7 +32,6 @@ type SortOrder = 'default' | 'asc' | 'desc';
 type UsersManagementScreenNavigationProp = NativeStackNavigationProp<researcherStackParamList, 'UsersManagement'>;
 
 interface User {
-    id: string;
     username: string;
     // credibilityScore: composite 0–100 score from backend UserProfileResponse
     credibilityScore: number;
@@ -85,16 +85,39 @@ export default function UsersManagementScreen() {
 
     const toggleBanStatus = useMutation({
         mutationFn: async ({ username, isBanned }: { username: string; isBanned: boolean }) => {
+            console.log(`[UsersManagement] Toggling ban status for ${username}. Target isBanned=${isBanned}`);
             const endpoint = isBanned
                 ? API_ENDPOINTS.USERS.UNBAN(username)
                 : API_ENDPOINTS.USERS.BAN(username);
             const res = await apiFetch(endpoint, { method: 'POST' });
-            if (!res.ok) throw new Error('Failed to toggle ban status');
-            return res.json();
+            if (!res.ok) {
+                const text = await res.text();
+                console.error(`[UsersManagement] API error: ${res.status} - ${text}`);
+                throw new Error(`Failed to toggle ban status. Server returned ${res.status}`);
+            }
+            const data = await res.json();
+            console.log(`[UsersManagement] API success. Updated user:`, data);
+            return data;
         },
-        onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: QUERY_KEYS.allUsers });
+        onSuccess: (updatedUser: User) => {
+            console.log(`[UsersManagement] onSuccess triggered for ${updatedUser.username}. Updating cache...`);
+            // Optimistically update the UI without waiting for network
+            queryClient.setQueryData(QUERY_KEYS.allUsers, (oldUsers: User[] | undefined) => {
+                if (!oldUsers) {
+                    console.log(`[UsersManagement] Cache miss for oldUsers.`);
+                    return oldUsers;
+                }
+                const newUsers = oldUsers.map((u) => u.username === updatedUser.username ? updatedUser : u);
+                console.log(`[UsersManagement] Cache updated. Length: ${newUsers.length}`);
+                return newUsers;
+            });
+            // Removed invalidateQueries here because aggressive network caching 
+            // of the GET request was instantly reverting the optimistic update.
         },
+        onError: (error) => {
+            console.error(`[UsersManagement] Mutation error:`, error);
+            Alert.alert("Error", error.message);
+        }
     });
 
     // ─── Web: table layout ────────────────────────────────────────────────────
@@ -127,7 +150,7 @@ export default function UsersManagementScreen() {
             <ScrollView style={webStyles.tableBody}>
                 {displayedUsers.map((item: User, index: number) => (
                     <View
-                        key={item.id}
+                        key={item.username}
                         style={[
                             webStyles.tableRow,
                             { borderBottomColor: themeColors.border },
@@ -258,7 +281,7 @@ export default function UsersManagementScreen() {
                         showsVerticalScrollIndicator={false}
                         data={displayedUsers}
                         renderItem={renderMobileCard}
-                        keyExtractor={item => item.id}
+                        keyExtractor={item => item.username}
                         numColumns={2}
                         contentContainerStyle={mobileStyles.listContent}
                         columnWrapperStyle={mobileStyles.columnWrapper}


### PR DESCRIPTION
Edited UsersManagementScreen.tsx

I have successfully implemented the fixes in `UsersManagementScreen.tsx`. 

Here is what was done:
1. **Removed the missing `id` dependency:** Updated the `User` interface to not require `id`, and switched the list renderers (both the Web table `ScrollView` and the Mobile `FlatList`) to use `username` as the unique React key instead of the `undefined` ID.
2. **Optimistic cache updates:** Updated the `onSuccess` handler inside the `useMutation` for `toggleBanStatus`. It now immediately patches the local cache with the newly updated `User` response from the backend. 

Because Expo is currently running, your app should hot-reload momentarily. You can now test the **Ban/Unban** buttons again. They should instantly visually toggle the user status on the screen without needing to reload or log out!

**The Root Cause:**
React Native's underlying network layer (especially on mobile) heavily caches `GET` requests. When you clicked the button, the POST request successfully changed the backend database. However, the `queryClient.invalidateQueries` function immediately fired off a background `GET` request to `/get-all` to sync the table. Because of the aggressive network caching, that `GET` request was served the old, stale data from the local OS cache (which still said the user was Active). This caused the UI to instantly overwrite our optimistic update with the old cached data, making it look like nothing changed.

**The Fix:**
I have removed the `invalidateQueries` call. Since the POST mutation to `ban/unban` returns the exact, newly updated user directly, we are safely injecting it into the local cache via `setQueryData`. By not triggering an immediate background refetch, we prevent the aggressive `GET` cache from reverting your screen. 

I've also added some detailed logging and an `Alert` popup just in case there is any other error failing silently.

Please try clicking the Ban/Unban button again. It should work perfectly now!