### PR TITLE
fixed dark mode bug

### DIFF
--- a/frontend/app/navigation/components/BottomBar.tsx
+++ b/frontend/app/navigation/components/BottomBar.tsx
@@ -25,7 +25,7 @@ export default function BottomBar({ items }: Props) {
     <View style={[styles.container, { backgroundColor: themeColors.card, borderColor: themeColors.border, paddingVertical: isDesktop ? 8 : 10 }]}>
       {items.map((item, idx) => (
         <TouchableOpacity
-          key={idx}
+          key={`${idx}-${theme}`}
           style={[styles.button, { padding: isDesktop ? 4 : 6 }]}
           onPress={() => navigation.navigate(item.route)}
         >


### PR DESCRIPTION
# Fix Plan: Theme Switch Icon Color Delay

## Root Cause Analysis
The issue where navigation bar icons don't update their color immediately upon theme switch is a known behavior with React Native's `<Image>` component on mobile platforms (iOS and Android). 

In `BottomBar.tsx`, the icons use a `tintColor` style property that depends on the current theme:
```tsx
<Image source={item.icon} style={[styles.icon, { tintColor: themeColors.text }]} />
```
When the theme changes, React updates the style object, but the native underlying image view sometimes caches the image and fails to repaint *only* the `tintColor` if the `source` prop hasn't changed. Interacting with the button (e.g., pressing it) forces the native view to repaint, which is why the color finally updates upon press.

## Implementation Plan

1. **Target File:** `frontend/app/navigation/components/BottomBar.tsx`
2. **Action:** Force a remount of the `<Image>` component (or its parent) whenever the theme changes.
3. **Code Change:**
   Update the `key` prop of the `TouchableOpacity` inside the `map` function to include the current `theme` string. This guarantees that React will treat the button (and its inner Image) as a completely new element when the theme toggles, bypassing the native caching issue.

**Before:**
```tsx
<TouchableOpacity
  key={idx}
  style={[styles.button, { padding: isDesktop ? 4 : 6 }]}
  onPress={() => navigation.navigate(item.route)}
>
  <Image source={item.icon} style={[styles.icon, { tintColor: themeColors.text }]} />
  {...}
</TouchableOpacity>
```

**After:**
```tsx
<TouchableOpacity
  key={`${idx}-${theme}`} // Appending theme forces a complete remount on theme change
  style={[styles.button, { padding: isDesktop ? 4 : 6 }]}
  onPress={() => navigation.navigate(item.route)}
>
  <Image source={item.icon} style={[styles.icon, { tintColor: themeColors.text }]} />
  {...}
</TouchableOpacity>
```

This single-line change will ensure all bottom navigation icons update instantaneously and synchronously with the rest of the application's theme colors.

Edited BottomBar.tsx

The fix has been successfully applied to `BottomBar.tsx`! 

I updated the component to include the theme in the `key` prop:
```tsx
<TouchableOpacity
  key={`${idx}-${theme}`}
  style={[styles.button, { padding: isDesktop ? 4 : 6 }]}
  onPress={() => navigation.navigate(item.route)}
>
```

This will force the native image views to remount immediately when the theme changes, ensuring the icons update their colors synchronously with the rest of the application without needing to be pressed first.

Since you're running Expo locally, the change should automatically hot-reload. Try switching the theme on your mobile device now—the bottom tab icons should update their colors instantaneously!
