### PR TITLE
Bugfix/gold images not showing up to users classifying

### DIFF
--- a/backend/src/main/java/com/swipelab/classification/api/GoldImageController.java
+++ b/backend/src/main/java/com/swipelab/classification/api/GoldImageController.java
@@ -71,28 +71,4 @@ public class GoldImageController {
         return ResponseEntity.noContent().build();
     }
 
-    /**
-     * Streams the raw image bytes for a locally-uploaded gold image.
-     * This endpoint is permitted without authentication (see SecurityConfig) so
-     * that React Native's Image component can load it without custom headers.
-     * No filesystem path is exposed — only the gold-image ID is used.
-     */
-    @GetMapping("/{id}/image")
-    @PreAuthorize("permitAll()")
-    public ResponseEntity<Resource> serveImage(@PathVariable Long id) {
-        Resource resource = goldImageService.getImageResource(id);
-        String contentType = "image/jpeg"; // fallback
-        try {
-            String filename = resource.getFilename();
-            if (filename != null) {
-                if (filename.endsWith(".png")) contentType = "image/png";
-                else if (filename.endsWith(".gif")) contentType = "image/gif";
-                else if (filename.endsWith(".webp")) contentType = "image/webp";
-            }
-        } catch (Exception ignored) {}
-        return ResponseEntity.ok()
-                .header(HttpHeaders.CACHE_CONTROL, "max-age=86400, public")
-                .contentType(MediaType.parseMediaType(contentType))
-                .body(resource);
-    }
 }

--- a/backend/src/main/java/com/swipelab/classification/api/GoldImageController.java
+++ b/backend/src/main/java/com/swipelab/classification/api/GoldImageController.java
@@ -39,10 +39,9 @@ public class GoldImageController {
     public ResponseEntity<GoldImageResponse> uploadGoldImage(
             @RequestParam(value = "file", required = false) org.springframework.web.multipart.MultipartFile file,
             @RequestParam(value = "imageUrl", required = false) String imageUrl,
-            @RequestParam("taskId") Long taskId,
             @RequestParam("species") String species,
             @RequestParam(value = "correctAnswer", defaultValue = "YES") String correctAnswer) {
-        GoldImageResponse response = goldImageService.uploadGoldImage(file, imageUrl, taskId, species, correctAnswer);
+        GoldImageResponse response = goldImageService.uploadGoldImage(file, imageUrl, species, correctAnswer);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 

--- a/backend/src/main/java/com/swipelab/classification/application/ClassificationService.java
+++ b/backend/src/main/java/com/swipelab/classification/application/ClassificationService.java
@@ -60,14 +60,25 @@ public class ClassificationService {
         ClassificationSubmittedEvent event;
         if (goldResult.isPresent()) {
             GoldImageEvaluationResult result = goldResult.get();
+
+            Classification classification = Classification.builder()
+                    .username(username)
+                    .userRole(userRole)
+                    .taskId(request.getTaskId())
+                    .image(image)
+                    .querySpecies(result.species())
+                    .userResponse(request.getDecision())
+                    .build();
+            Classification saved = classificationRepository.save(classification);
+
             event = ClassificationSubmittedEvent.builder()
                     .username(username)
-                    .classificationId(null)
+                    .classificationId(saved.getId())
                     .imageId(image.getId())
                     .taskId(request.getTaskId())
                     .isCorrect(result.isCorrect())
                     .isGoldStandard(true)
-                    .submittedAt(LocalDateTime.now())
+                    .submittedAt(saved.getCreatedAt())
                     .species(result.species())
                     .userResponse(request.getDecision())
                     .responseTimeMs(request.getResponseTimeMs())
@@ -136,14 +147,25 @@ public class ClassificationService {
             ClassificationSubmittedEvent event;
             if (goldResult.isPresent()) {
                 GoldImageEvaluationResult result = goldResult.get();
+
+                Classification classification = Classification.builder()
+                        .username(username)
+                        .userRole(userRole)
+                        .taskId(taskId)
+                        .image(image)
+                        .querySpecies(result.species())
+                        .userResponse(response.getUserResponse())
+                        .build();
+                Classification saved = classificationRepository.save(classification);
+
                 event = ClassificationSubmittedEvent.builder()
                         .username(username)
-                        .classificationId(null)
+                        .classificationId(saved.getId())
                         .imageId(image.getId())
                         .taskId(taskId)
                         .isCorrect(result.isCorrect())
                         .isGoldStandard(true)
-                        .submittedAt(LocalDateTime.now())
+                        .submittedAt(saved.getCreatedAt())
                         .species(result.species())
                         .userResponse(response.getUserResponse())
                         .userCredibility(null)

--- a/backend/src/main/java/com/swipelab/classification/domain/FrequencyBasedGoldImagePolicy.java
+++ b/backend/src/main/java/com/swipelab/classification/domain/FrequencyBasedGoldImagePolicy.java
@@ -21,9 +21,11 @@ public class FrequencyBasedGoldImagePolicy implements GoldImagePolicy {
     private final ClassificationRepository classificationRepository;
 
     @Override
-    public boolean shouldServeGoldImage(String username, Long taskId) {
+    public boolean shouldIncludeGoldImageInBatch(String username, Long taskId, int batchSize) {
         Long count = classificationRepository.countByUsernameAndTaskId(username, taskId);
-        if (count == null || count == 0) return false;
-        return count % GOLD_IMAGE_FREQUENCY == 0;
+        long safeCount = count == null ? 0 : count;
+        long currentInterval = safeCount / GOLD_IMAGE_FREQUENCY;
+        long nextInterval = (safeCount + batchSize) / GOLD_IMAGE_FREQUENCY;
+        return nextInterval > currentInterval;
     }
 }

--- a/backend/src/main/java/com/swipelab/classification/domain/GoldImagePolicy.java
+++ b/backend/src/main/java/com/swipelab/classification/domain/GoldImagePolicy.java
@@ -9,12 +9,5 @@ package com.swipelab.classification.domain;
  */
 public interface GoldImagePolicy {
 
-    /**
-     * Returns true if the next image served to this user for this task
-     * should be a gold-standard image.
-     *
-     * @param username the user being served
-     * @param taskId   the task context
-     */
-    boolean shouldServeGoldImage(String username, Long taskId);
+    boolean shouldIncludeGoldImageInBatch(String username, Long taskId, int batchSize);
 }

--- a/backend/src/main/java/com/swipelab/classification/domain/GoldImageService.java
+++ b/backend/src/main/java/com/swipelab/classification/domain/GoldImageService.java
@@ -45,7 +45,7 @@ public class GoldImageService {
     }
 
     @Transactional
-    public GoldImageResponse uploadGoldImage(MultipartFile file, String imageUrl, Long taskId, String species, String correctAnswerStr) {
+    public GoldImageResponse uploadGoldImage(MultipartFile file, String imageUrl, String species, String correctAnswerStr) {
         String srcPath;
         if (file != null && !file.isEmpty()) {
             srcPath = fileStorageService.storeFile(file);
@@ -57,11 +57,9 @@ public class GoldImageService {
             throw new IllegalArgumentException("Either file or imageUrl must be provided");
         }
 
-        TaskProvider.TaskInfo taskInfo = taskProvider.getTaskInfo(taskId);
-
         Image image = Image.builder()
                 .srcPath(srcPath)
-                .taskId(taskInfo.id())
+                .taskId(null)
                 .build();
         Image savedImage = imageRepository.save(image);
 
@@ -84,8 +82,10 @@ public class GoldImageService {
 
     @Transactional(readOnly = true)
     public List<GoldImageResponse> getGoldImagesByTask(Long taskId) {
+        TaskProvider.TaskInfo taskInfo = taskProvider.getTaskInfo(taskId);
+        List<String> taskSpecies = taskInfo.targetSpeciesNames();
         return goldImageRepository.findAllByActiveTrue().stream()
-                .filter(g -> g.getImage().getTaskId().equals(taskId))
+                .filter(g -> taskSpecies != null && taskSpecies.contains(g.getSpecies()))
                 .map(this::mapToResponse)
                 .collect(Collectors.toList());
     }

--- a/backend/src/main/java/com/swipelab/classification/domain/GoldImageService.java
+++ b/backend/src/main/java/com/swipelab/classification/domain/GoldImageService.java
@@ -26,7 +26,6 @@ public class GoldImageService {
 
     private final GoldImageRepository goldImageRepository;
     private final ImageRepository imageRepository;
-    private final FileStorageService fileStorageService;
     private final TaskProvider taskProvider;
 
     @Transactional
@@ -48,11 +47,16 @@ public class GoldImageService {
     public GoldImageResponse uploadGoldImage(MultipartFile file, String imageUrl, String species, String correctAnswerStr) {
         String srcPath;
         if (file != null && !file.isEmpty()) {
-            srcPath = fileStorageService.storeFile(file);
+            try {
+                byte[] bytes = file.getBytes();
+                String base64 = java.util.Base64.getEncoder().encodeToString(bytes);
+                String contentType = file.getContentType() != null ? file.getContentType() : "image/jpeg";
+                srcPath = "data:" + contentType + ";base64," + base64;
+            } catch (java.io.IOException e) {
+                throw new RuntimeException("Could not read uploaded file", e);
+            }
         } else if (imageUrl != null && !imageUrl.isEmpty()) {
-            // Download and store locally — we never keep raw external URLs so images
-            // remain accessible even if the original link is later deleted.
-            srcPath = fileStorageService.storeFileFromUrl(imageUrl);
+            srcPath = downloadUrlAsBase64(imageUrl);
         } else {
             throw new IllegalArgumentException("Either file or imageUrl must be provided");
         }
@@ -120,18 +124,12 @@ public class GoldImageService {
 
     private GoldImageResponse mapToResponse(GoldImage goldImage) {
         String srcPath = goldImage.getImage().getSrcPath();
-        // For locally uploaded files, expose them through the dedicated image endpoint
-        // so no filesystem path is ever revealed to the client.
-        // External URL images (stored as full http/https URLs) are returned as-is.
-        String resolvedUrl = (srcPath != null && srcPath.startsWith("/uploads/"))
-                ? appBaseUrl.replaceAll("/$", "") + "/api/admin/gold-images/" + goldImage.getId() + "/image"
-                : srcPath;
         return GoldImageResponse.builder()
                 .id(goldImage.getId())
                 .imageId(goldImage.getImage().getId())
                 .species(goldImage.getSpecies())
                 .correctAnswer(goldImage.getCorrectAnswer())
-                .imageUrl(resolvedUrl)
+                .imageUrl(srcPath)
                 .build();
     }
 
@@ -142,19 +140,39 @@ public class GoldImageService {
                 .collect(Collectors.toList());
     }
 
-    /**
-     * Returns a file Resource for streaming image bytes.
-     * Only valid for locally-uploaded images (srcPath starts with /uploads/).
-     * Throws if the image was stored as an external URL.
-     */
-    @Transactional(readOnly = true)
-    public Resource getImageResource(Long goldImageId) {
-        GoldImage goldImage = goldImageRepository.findById(goldImageId)
-                .orElseThrow(() -> new ResourceNotFoundException("Gold Image not found: " + goldImageId));
-        String srcPath = goldImage.getImage().getSrcPath();
-        if (srcPath == null || !srcPath.startsWith("/uploads/")) {
-            throw new IllegalArgumentException("Image is not a locally stored upload");
+    private String downloadUrlAsBase64(String imageUrl) {
+        java.net.HttpURLConnection connection = null;
+        try {
+            java.net.URI uri = java.net.URI.create(imageUrl);
+            connection = (java.net.HttpURLConnection) uri.toURL().openConnection();
+            connection.setRequestMethod("GET");
+            connection.setConnectTimeout(15000);
+            connection.setReadTimeout(15000);
+            connection.setRequestProperty("User-Agent", "Mozilla/5.0");
+            connection.connect();
+
+            int status = connection.getResponseCode();
+            if (status < 200 || status >= 300) {
+                throw new RuntimeException("Remote URL returned HTTP " + status);
+            }
+
+            String contentType = connection.getContentType();
+            if (contentType == null) contentType = "image/jpeg";
+
+            try (java.io.InputStream in = connection.getInputStream();
+                 java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream()) {
+                byte[] buffer = new byte[8192];
+                int bytesRead;
+                while ((bytesRead = in.read(buffer)) != -1) {
+                    out.write(buffer, 0, bytesRead);
+                }
+                String base64 = java.util.Base64.getEncoder().encodeToString(out.toByteArray());
+                return "data:" + contentType + ";base64," + base64;
+            }
+        } catch (java.io.IOException ex) {
+            throw new RuntimeException("Could not download image from URL: " + imageUrl, ex);
+        } finally {
+            if (connection != null) connection.disconnect();
         }
-        return fileStorageService.loadFile(srcPath);
     }
 }

--- a/backend/src/main/java/com/swipelab/classification/domain/Image.java
+++ b/backend/src/main/java/com/swipelab/classification/domain/Image.java
@@ -65,7 +65,7 @@ public class Image {
      * private Label correctLabel;
      */
 
-    @Column(name = "task_id", nullable = false)
+    @Column(name = "task_id")
     private Long taskId;
 
     @CreationTimestamp

--- a/backend/src/main/java/com/swipelab/classification/domain/ImageService.java
+++ b/backend/src/main/java/com/swipelab/classification/domain/ImageService.java
@@ -138,7 +138,14 @@ public class ImageService {
 
                 // Local file path — read from disk and return as base64
                 try {
-                        java.io.File file = new java.io.File(path);
+                        java.io.File file;
+                        if (path.startsWith("/uploads/")) {
+                                String filename = java.nio.file.Paths.get(path).getFileName().toString();
+                                file = java.nio.file.Paths.get("uploads").toAbsolutePath().normalize().resolve(filename).toFile();
+                        } else {
+                                file = new java.io.File(path);
+                        }
+                        
                         if (file.exists() && file.isFile()) {
                                 byte[] bytes = java.nio.file.Files.readAllBytes(file.toPath());
                                 return java.util.Base64.getEncoder().encodeToString(bytes);
@@ -280,7 +287,14 @@ public class ImageService {
                 }
 
                 try {
-                        java.io.File file = new java.io.File(path);
+                        java.io.File file;
+                        if (path.startsWith("/uploads/")) {
+                                String filename = java.nio.file.Paths.get(path).getFileName().toString();
+                                file = java.nio.file.Paths.get("uploads").toAbsolutePath().normalize().resolve(filename).toFile();
+                        } else {
+                                file = new java.io.File(path);
+                        }
+                        
                         if (file.exists() && file.isFile()) {
                                 byte[] bytes = java.nio.file.Files.readAllBytes(file.toPath());
                                 return ResponseEntity.ok()

--- a/backend/src/main/java/com/swipelab/classification/domain/ImageService.java
+++ b/backend/src/main/java/com/swipelab/classification/domain/ImageService.java
@@ -36,6 +36,7 @@ public class ImageService {
         private final ClassificationRepository classificationRepository;
         private final GoldImageRepository goldImageRepository;
         private final TaskDistributionService taskDistributionService;
+        private final GoldImagePolicy goldImagePolicy;
 
         @Transactional(readOnly = true)
         public NextBatchResponse getNextBatchForApi(Long taskId, String username, int count) {
@@ -46,9 +47,22 @@ public class ImageService {
                 int attempt = 0;
                 int found = 0;
 
+                boolean shouldIncludeGoldImage = goldImagePolicy.shouldIncludeGoldImageInBatch(username, taskId, count);
+                boolean goldImageAdded = false;
+
                 while (found < count && attempt < count * 3) {
-                        Optional<TaskDistributionService.ImageSpeciesPair> pairOpt =
-                                taskDistributionService.getNextImageForUser(username, taskId, taskSpecies);
+                        Optional<TaskDistributionService.ImageSpeciesPair> pairOpt;
+                        if (shouldIncludeGoldImage && !goldImageAdded) {
+                                pairOpt = taskDistributionService.getNextGoldImagePair(username, taskId, taskSpecies);
+                                if (pairOpt.isPresent()) {
+                                        goldImageAdded = true;
+                                } else {
+                                        pairOpt = taskDistributionService.getNextRegularImagePair(username, taskId, taskSpecies);
+                                }
+                        } else {
+                                pairOpt = taskDistributionService.getNextRegularImagePair(username, taskId, taskSpecies);
+                        }
+
                         if (pairOpt.isEmpty()) break;
 
                         TaskDistributionService.ImageSpeciesPair pair = pairOpt.get();

--- a/backend/src/main/java/com/swipelab/classification/domain/TaskDistributionService.java
+++ b/backend/src/main/java/com/swipelab/classification/domain/TaskDistributionService.java
@@ -18,32 +18,18 @@ public class TaskDistributionService {
     private final ImageRepository imageRepository;
     private final ClassificationRepository classificationRepository;
     private final com.swipelab.classification.infrastructure.GoldImageRepository goldImageRepository;
-    private final GoldImagePolicy goldImagePolicy;
 
     /**
      * Holds the selected image and the species to query for that image.
      */
     public record ImageSpeciesPair(Image image, String species) {}
 
-    /**
-     * Get the next image+species pair for a user to classify.
-     * The same image may reappear with a different species if the user has not yet
-     * classified it for all species in the task.
-     */
-    @Transactional(readOnly = true)
-    public Optional<ImageSpeciesPair> getNextImageForUser(String username, Long taskId, List<String> taskSpecies) {
-        if (goldImagePolicy.shouldServeGoldImage(username, taskId)) {
-            Optional<ImageSpeciesPair> goldPair = getNextGoldImagePair(username, taskId, taskSpecies);
-            if (goldPair.isPresent()) return goldPair;
-        }
 
-        return getNextRegularImagePair(username, taskId, taskSpecies);
-    }
 
     /**
      * Get next gold standard image+species pair that user hasn't classified yet for that species.
      */
-    private Optional<ImageSpeciesPair> getNextGoldImagePair(String username, Long taskId, List<String> taskSpecies) {
+    public Optional<ImageSpeciesPair> getNextGoldImagePair(String username, Long taskId, List<String> taskSpecies) {
         if (taskSpecies == null || taskSpecies.isEmpty()) return Optional.empty();
         
         List<Image> goldImages = imageRepository.findUnclassifiedGoldImages(username, taskSpecies);
@@ -62,7 +48,7 @@ public class TaskDistributionService {
      * Get next regular image+species pair, prioritising images with fewer total classifications.
      * Candidates are images the user hasn't classified for EVERY species yet.
      */
-    private Optional<ImageSpeciesPair> getNextRegularImagePair(String username, Long taskId, List<String> taskSpecies) {
+    public Optional<ImageSpeciesPair> getNextRegularImagePair(String username, Long taskId, List<String> taskSpecies) {
         int speciesCount = taskSpecies == null || taskSpecies.isEmpty() ? 1 : taskSpecies.size();
         List<Image> candidates = imageRepository.findRegularImageCandidatesForUser(
                 username, taskId, speciesCount, PageRequest.of(0, 20));

--- a/backend/src/main/java/com/swipelab/classification/domain/TaskDistributionService.java
+++ b/backend/src/main/java/com/swipelab/classification/domain/TaskDistributionService.java
@@ -17,6 +17,7 @@ public class TaskDistributionService {
 
     private final ImageRepository imageRepository;
     private final ClassificationRepository classificationRepository;
+    private final com.swipelab.classification.infrastructure.GoldImageRepository goldImageRepository;
     private final GoldImagePolicy goldImagePolicy;
 
     /**
@@ -43,12 +44,16 @@ public class TaskDistributionService {
      * Get next gold standard image+species pair that user hasn't classified yet for that species.
      */
     private Optional<ImageSpeciesPair> getNextGoldImagePair(String username, Long taskId, List<String> taskSpecies) {
-        List<Image> goldImages = imageRepository.findUnclassifiedGoldImages(username, taskId);
+        if (taskSpecies == null || taskSpecies.isEmpty()) return Optional.empty();
+        
+        List<Image> goldImages = imageRepository.findUnclassifiedGoldImages(username, taskSpecies);
         if (goldImages.isEmpty()) return Optional.empty();
 
         for (Image image : goldImages) {
-            String species = pickUnqueriedSpecies(username, image.getId(), taskSpecies);
-            if (species != null) return Optional.of(new ImageSpeciesPair(image, species));
+            Optional<com.swipelab.classification.domain.GoldImage> goldOpt = goldImageRepository.findByImageIdAndActiveTrue(image.getId());
+            if (goldOpt.isPresent()) {
+                return Optional.of(new ImageSpeciesPair(image, goldOpt.get().getSpecies()));
+            }
         }
         return Optional.empty();
     }

--- a/backend/src/main/java/com/swipelab/classification/infrastructure/ImageRepository.java
+++ b/backend/src/main/java/com/swipelab/classification/infrastructure/ImageRepository.java
@@ -21,10 +21,11 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
     Image findByExternalBoxId(Long externalBoxId);
 
     // Find all unclassified gold standard images for a specific task and user
-    @Query("SELECT i FROM Image i WHERE i.taskId = :taskId " +
-            "AND i.id IN (SELECT g.image.id FROM GoldImage g) " +
+    @Query("SELECT i FROM Image i JOIN GoldImage g ON g.image.id = i.id " +
+            "WHERE g.active = true " +
+            "AND g.species IN :taskSpecies " +
             "AND NOT EXISTS (SELECT c FROM Classification c WHERE c.image.id = i.id AND c.username = :username)")
-    List<Image> findUnclassifiedGoldImages(@Param("username") String username, @Param("taskId") Long taskId);
+    List<Image> findUnclassifiedGoldImages(@Param("username") String username, @Param("taskSpecies") List<String> taskSpecies);
 
     /**
      * Find regular (non-gold) images for a task where the user still has at least one

--- a/backend/src/main/java/com/swipelab/users/application/CredibilityEventListener.java
+++ b/backend/src/main/java/com/swipelab/users/application/CredibilityEventListener.java
@@ -9,7 +9,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 /**
  * Listens to ClassificationSubmittedEvent and triggers credibility recalculation
@@ -45,8 +48,8 @@ public class CredibilityEventListener {
     private int minClassificationsForConsensus;
 
     @Async
-    @EventListener
-    @Transactional
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void onClassificationSubmitted(ClassificationSubmittedEvent event) {
         // Gold-image classifications are handled separately by GoldImageEvaluatorService
         // (they feed CredibilityRecord). Still trigger regular credibility refresh below.

--- a/backend/src/main/java/com/swipelab/users/infrastructure/DataMigrationRunner.java
+++ b/backend/src/main/java/com/swipelab/users/infrastructure/DataMigrationRunner.java
@@ -1,5 +1,9 @@
 package com.swipelab.users.infrastructure;
 
+import com.swipelab.classification.domain.Classification;
+import com.swipelab.classification.domain.CredibilityRecord;
+import com.swipelab.classification.infrastructure.ClassificationRepository;
+import com.swipelab.classification.infrastructure.CredibilityRepository;
 import com.swipelab.model.enums.UserStatus;
 import com.swipelab.users.domain.User;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +19,8 @@ import java.util.List;
 public class DataMigrationRunner implements CommandLineRunner {
 
     private final UserRepository userRepository;
+    private final CredibilityRepository credibilityRepository;
+    private final ClassificationRepository classificationRepository;
 
     @Override
     public void run(String... args) throws Exception {
@@ -46,5 +52,30 @@ public class DataMigrationRunner implements CommandLineRunner {
              }
         }
         log.info("Data migration completed. Updated {} users.", updated);
+
+        log.info("Running Gold Image Classification backfill migration...");
+        List<CredibilityRecord> records = credibilityRepository.findAll();
+        int backfilled = 0;
+        for (CredibilityRecord record : records) {
+            boolean exists = classificationRepository.existsByUsernameAndImageId(record.getUsername(), record.getGoldImage().getImage().getId());
+            if (!exists) {
+                // Determine user role (fallback to USER if not found)
+                String role = userRepository.findByUsername(record.getUsername())
+                        .map(u -> u.getRole().name())
+                        .orElse("USER");
+
+                Classification classification = Classification.builder()
+                        .username(record.getUsername())
+                        .userRole(role)
+                        .taskId(record.getTaskId())
+                        .image(record.getGoldImage().getImage())
+                        .querySpecies(record.getQuerySpecies())
+                        .userResponse(record.getUserResponse())
+                        .build();
+                classificationRepository.save(classification);
+                backfilled++;
+            }
+        }
+        log.info("Gold Image Classification backfill completed. Inserted {} missing classifications.", backfilled);
     }
 }

--- a/backend/src/main/java/com/swipelab/users/infrastructure/DataMigrationRunner.java
+++ b/backend/src/main/java/com/swipelab/users/infrastructure/DataMigrationRunner.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -23,6 +24,7 @@ public class DataMigrationRunner implements CommandLineRunner {
     private final ClassificationRepository classificationRepository;
 
     @Override
+    @Transactional
     public void run(String... args) throws Exception {
         log.info("Running User Status data migration...");
         List<User> users = userRepository.findAll();

--- a/backend/src/main/resources/db/migration/V19__make_images_task_id_nullable.sql
+++ b/backend/src/main/resources/db/migration/V19__make_images_task_id_nullable.sql
@@ -1,0 +1,1 @@
+ALTER TABLE images ALTER COLUMN task_id DROP NOT NULL;

--- a/backend/src/test/java/com/swipelab/classification/api/GoldImageControllerTest.java
+++ b/backend/src/test/java/com/swipelab/classification/api/GoldImageControllerTest.java
@@ -113,35 +113,6 @@ class GoldImageControllerTest {
         verify(goldImageService, times(1)).deleteGoldImage(1L);
     }
 
-    // ── serveImage ─────────────────────────────────────────────────────────
-
-    @Test
-    void serveImage_ShouldReturnImageBytes_WithCorrectContentType() throws Exception {
-        byte[] imageBytes = new byte[]{(byte) 0x89, 0x50, 0x4E, 0x47}; // PNG magic bytes
-        Resource resource = new ByteArrayResource(imageBytes) {
-            @Override
-            public String getFilename() { return "test-uuid.png"; }
-        };
-        when(goldImageService.getImageResource(1L)).thenReturn(resource);
-
-        mockMvc.perform(get("/api/admin/gold-images/1/image"))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.IMAGE_PNG))
-                .andExpect(header().string("Cache-Control", "max-age=86400, public"));
-
-        verify(goldImageService).getImageResource(1L);
-    }
-
-    @Test
-    void serveImage_ShouldPropagateException_WhenResourceNotFound() {
-        // Standalone MockMvc wraps unhandled RuntimeExceptions in a ServletException,
-        // so we assert the exception propagates rather than checking the HTTP status.
-        when(goldImageService.getImageResource(99L))
-                .thenThrow(new RuntimeException("File not found or not readable: missing.jpg"));
-
-        org.junit.jupiter.api.Assertions.assertThrows(Exception.class,
-                () -> mockMvc.perform(get("/api/admin/gold-images/99/image")));
-    }
 }
 
 

--- a/backend/src/test/java/com/swipelab/classification/application/ClassificationServiceTest.java
+++ b/backend/src/test/java/com/swipelab/classification/application/ClassificationServiceTest.java
@@ -99,11 +99,15 @@ class ClassificationServiceTest {
         when(fraudDetectionService.analyzeClassification(anyString(), anyString(), anyLong(), anyLong()))
                 .thenReturn(new FraudAnalysisResult(false, null));
 
+        Classification savedClassification = new Classification();
+        savedClassification.setId(10L);
+        when(classificationRepository.save(any(Classification.class))).thenReturn(savedClassification);
+
         classificationService.submitClassification("testuser", "USER", 0.8, request);
 
         verify(fraudDetectionService, times(1)).analyzeClassification("testuser", "USER", 1500L, 1L);
         verify(goldImageEvaluatorService, times(1)).evaluate(any(), any(), any(), any());
-        verify(classificationRepository, never()).save(any());
+        verify(classificationRepository, times(1)).save(any(Classification.class));
 
         ArgumentCaptor<ClassificationSubmittedEvent> eventCaptor = ArgumentCaptor.forClass(ClassificationSubmittedEvent.class);
         verify(eventPublisher, times(1)).publishEvent(eventCaptor.capture());

--- a/backend/src/test/java/com/swipelab/classification/domain/GoldImageServiceTest.java
+++ b/backend/src/test/java/com/swipelab/classification/domain/GoldImageServiceTest.java
@@ -36,9 +36,6 @@ class GoldImageServiceTest {
     private ImageRepository imageRepository;
 
     @Mock
-    private FileStorageService fileStorageService;
-
-    @Mock
     private TaskProvider taskProvider;
 
     @InjectMocks
@@ -102,10 +99,11 @@ class GoldImageServiceTest {
     // ── uploadGoldImage ──────────────────────────────────────────────────────
 
     @Test
-    void uploadGoldImage_WithFile_ShouldStoreFileAndReturnResponse() {
+    void uploadGoldImage_WithFile_ShouldStoreFileAndReturnResponse() throws java.io.IOException {
         MultipartFile mockFile = mock(MultipartFile.class);
         when(mockFile.isEmpty()).thenReturn(false);
-        when(fileStorageService.storeFile(mockFile)).thenReturn("/uploads/stored-uuid.png");
+        when(mockFile.getBytes()).thenReturn(new byte[]{1, 2, 3});
+        when(mockFile.getContentType()).thenReturn("image/jpeg");
 
         when(imageRepository.save(any(Image.class))).thenReturn(image);
         when(goldImageRepository.save(any(GoldImage.class))).thenReturn(goldImage);
@@ -114,96 +112,12 @@ class GoldImageServiceTest {
 
         assertNotNull(response);
         assertEquals(1L, response.getId());
-        // imageUrl must resolve to the opaque API endpoint, not the raw file path
-        assertTrue(response.getImageUrl().contains("/api/admin/gold-images/1/image"));
-        verify(fileStorageService).storeFile(mockFile);
-        verify(fileStorageService, never()).storeFileFromUrl(any());
-    }
-
-    @Test
-    void uploadGoldImage_WithUrl_ShouldDownloadAndStoreLocally() {
-        String remoteUrl = "https://example.com/bee.jpg";
-        when(fileStorageService.storeFileFromUrl(remoteUrl)).thenReturn("/uploads/downloaded-uuid.jpg");
-
-        when(imageRepository.save(any(Image.class))).thenReturn(image);
-        when(goldImageRepository.save(any(GoldImage.class))).thenReturn(goldImage);
-
-        GoldImageResponse response = goldImageService.uploadGoldImage(null, remoteUrl, "Lion", "YES");
-
-        assertNotNull(response);
-        // External URL must never be returned as imageUrl — it must be the local API endpoint
-        assertFalse(response.getImageUrl().startsWith("https://example.com"),
-                "Raw external URL must not leak into the response");
-        assertTrue(response.getImageUrl().contains("/api/admin/gold-images/"),
-                "Response imageUrl should point to the internal image endpoint");
-        verify(fileStorageService).storeFileFromUrl(remoteUrl);
-        verify(fileStorageService, never()).storeFile(any());
     }
 
     @Test
     void uploadGoldImage_WithNeitherFileNorUrl_ShouldThrow() {
         assertThrows(IllegalArgumentException.class,
                 () -> goldImageService.uploadGoldImage(null, null, "Lion", "YES"));
-        verify(fileStorageService, never()).storeFile(any());
-        verify(fileStorageService, never()).storeFileFromUrl(any());
-    }
-
-    // ── mapToResponse / imageUrl resolution ──────────────────────────────────
-
-    @Test
-    void getGoldImageById_ShouldReturnAbsoluteApiUrl_ForLocalUpload() {
-        when(goldImageRepository.findById(1L)).thenReturn(Optional.of(goldImage));
-
-        GoldImageResponse response = goldImageService.getGoldImageById(1L);
-
-        assertNotNull(response);
-        assertEquals(
-                APP_BASE_URL + "/api/admin/gold-images/1/image",
-                response.getImageUrl(),
-                "Locally uploaded images should be served via the API endpoint"
-        );
-    }
-
-    @Test
-    void mapToResponse_ShouldPassThroughExternalUrl_WhenSrcPathIsHttp() {
-        image.setSrcPath("https://external.example.com/bee.jpg");
-        when(goldImageRepository.findById(1L)).thenReturn(Optional.of(goldImage));
-
-        GoldImageResponse response = goldImageService.getGoldImageById(1L);
-
-        assertEquals("https://external.example.com/bee.jpg", response.getImageUrl(),
-                "External URLs stored as srcPath should be returned unchanged");
-    }
-
-    // ── getImageResource ─────────────────────────────────────────────────────
-
-    @Test
-    void getImageResource_ShouldReturnResource_ForLocalUpload() {
-        Resource mockResource = mock(Resource.class);
-        when(goldImageRepository.findById(1L)).thenReturn(Optional.of(goldImage));
-        when(fileStorageService.loadFile("/uploads/test-uuid.jpg")).thenReturn(mockResource);
-
-        Resource result = goldImageService.getImageResource(1L);
-
-        assertSame(mockResource, result);
-        verify(fileStorageService).loadFile("/uploads/test-uuid.jpg");
-    }
-
-    @Test
-    void getImageResource_ShouldThrow_WhenImageNotFound() {
-        when(goldImageRepository.findById(99L)).thenReturn(Optional.empty());
-
-        assertThrows(ResourceNotFoundException.class, () -> goldImageService.getImageResource(99L));
-        verify(fileStorageService, never()).loadFile(any());
-    }
-
-    @Test
-    void getImageResource_ShouldThrow_WhenSrcPathIsExternalUrl() {
-        image.setSrcPath("https://external.example.com/bee.jpg");
-        when(goldImageRepository.findById(1L)).thenReturn(Optional.of(goldImage));
-
-        assertThrows(IllegalArgumentException.class, () -> goldImageService.getImageResource(1L),
-                "Requesting image bytes for an external-URL image must throw");
     }
 
     // ── other CRUD ───────────────────────────────────────────────────────────

--- a/backend/src/test/java/com/swipelab/classification/domain/GoldImageServiceTest.java
+++ b/backend/src/test/java/com/swipelab/classification/domain/GoldImageServiceTest.java
@@ -106,11 +106,11 @@ class GoldImageServiceTest {
         MultipartFile mockFile = mock(MultipartFile.class);
         when(mockFile.isEmpty()).thenReturn(false);
         when(fileStorageService.storeFile(mockFile)).thenReturn("/uploads/stored-uuid.png");
-        when(taskProvider.getTaskInfo(1L)).thenReturn(taskInfo);
+
         when(imageRepository.save(any(Image.class))).thenReturn(image);
         when(goldImageRepository.save(any(GoldImage.class))).thenReturn(goldImage);
 
-        GoldImageResponse response = goldImageService.uploadGoldImage(mockFile, null, 1L, "Lion", "YES");
+        GoldImageResponse response = goldImageService.uploadGoldImage(mockFile, null, "Lion", "YES");
 
         assertNotNull(response);
         assertEquals(1L, response.getId());
@@ -124,11 +124,11 @@ class GoldImageServiceTest {
     void uploadGoldImage_WithUrl_ShouldDownloadAndStoreLocally() {
         String remoteUrl = "https://example.com/bee.jpg";
         when(fileStorageService.storeFileFromUrl(remoteUrl)).thenReturn("/uploads/downloaded-uuid.jpg");
-        when(taskProvider.getTaskInfo(1L)).thenReturn(taskInfo);
+
         when(imageRepository.save(any(Image.class))).thenReturn(image);
         when(goldImageRepository.save(any(GoldImage.class))).thenReturn(goldImage);
 
-        GoldImageResponse response = goldImageService.uploadGoldImage(null, remoteUrl, 1L, "Lion", "YES");
+        GoldImageResponse response = goldImageService.uploadGoldImage(null, remoteUrl, "Lion", "YES");
 
         assertNotNull(response);
         // External URL must never be returned as imageUrl — it must be the local API endpoint
@@ -143,7 +143,7 @@ class GoldImageServiceTest {
     @Test
     void uploadGoldImage_WithNeitherFileNorUrl_ShouldThrow() {
         assertThrows(IllegalArgumentException.class,
-                () -> goldImageService.uploadGoldImage(null, null, 1L, "Lion", "YES"));
+                () -> goldImageService.uploadGoldImage(null, null, "Lion", "YES"));
         verify(fileStorageService, never()).storeFile(any());
         verify(fileStorageService, never()).storeFileFromUrl(any());
     }
@@ -210,6 +210,7 @@ class GoldImageServiceTest {
 
     @Test
     void getGoldImagesByTask_ShouldReturnValidList() {
+        when(taskProvider.getTaskInfo(1L)).thenReturn(new TaskProvider.TaskInfo(1L, "Q", "S", Collections.singletonList("Lion"), Collections.emptyList()));
         when(goldImageRepository.findAllByActiveTrue()).thenReturn(Collections.singletonList(goldImage));
 
         List<GoldImageResponse> responses = goldImageService.getGoldImagesByTask(1L);

--- a/backend/src/test/java/com/swipelab/classification/domain/ImageServiceTest.java
+++ b/backend/src/test/java/com/swipelab/classification/domain/ImageServiceTest.java
@@ -49,6 +49,9 @@ class ImageServiceTest {
     @Mock
     private TaskDistributionService taskDistributionService;
 
+    @Mock
+    private GoldImagePolicy goldImagePolicy;
+
     @InjectMocks
     private ImageService imageService;
 
@@ -69,8 +72,8 @@ class ImageServiceTest {
     @Test
     void getNextBatchForApi_ShouldReturnImages() {
         when(taskProvider.getTaskInfo(1L)).thenReturn(taskInfo);
-        // task has no targetSpecies so species list is empty → question comes from task.getQuestion()
-        when(taskDistributionService.getNextImageForUser(anyString(), anyLong(), anyList()))
+        when(goldImagePolicy.shouldIncludeGoldImageInBatch("testuser", 1L, 5)).thenReturn(false);
+        when(taskDistributionService.getNextRegularImagePair(anyString(), anyLong(), anyList()))
                 .thenReturn(Optional.of(new TaskDistributionService.ImageSpeciesPair(image, null)))
                 .thenReturn(Optional.empty());
 

--- a/backend/src/test/java/com/swipelab/classification/domain/TaskDistributionServiceTest.java
+++ b/backend/src/test/java/com/swipelab/classification/domain/TaskDistributionServiceTest.java
@@ -28,6 +28,9 @@ class TaskDistributionServiceTest {
     private ClassificationRepository classificationRepository;
 
     @Mock
+    private com.swipelab.classification.infrastructure.GoldImageRepository goldImageRepository;
+
+    @Mock
     private GoldImagePolicy goldImagePolicy;
 
     @InjectMocks
@@ -72,10 +75,12 @@ class TaskDistributionServiceTest {
     @Test
     void getNextImageForUser_ShouldReturnGoldImage_WhenPolicySaysGold() {
         when(goldImagePolicy.shouldServeGoldImage("testuser", 1L)).thenReturn(true);
-        when(imageRepository.findUnclassifiedGoldImages("testuser", 1L))
+        when(imageRepository.findUnclassifiedGoldImages("testuser", SPECIES))
                 .thenReturn(List.of(goldImage));
-        when(classificationRepository.findQueriedSpeciesByUsernameAndImageId("testuser", 3L))
-                .thenReturn(Collections.emptyList());
+        
+        com.swipelab.classification.domain.GoldImage mockGoldImage = new com.swipelab.classification.domain.GoldImage();
+        mockGoldImage.setSpecies("Bat");
+        when(goldImageRepository.findByImageIdAndActiveTrue(3L)).thenReturn(Optional.of(mockGoldImage));
 
         Optional<TaskDistributionService.ImageSpeciesPair> result =
                 taskDistributionService.getNextImageForUser("testuser", 1L, SPECIES);
@@ -88,7 +93,7 @@ class TaskDistributionServiceTest {
     @Test
     void getNextImageForUser_ShouldFallbackToRegularImage_WhenNoGoldAvailable() {
         when(goldImagePolicy.shouldServeGoldImage("testuser", 1L)).thenReturn(true);
-        when(imageRepository.findUnclassifiedGoldImages("testuser", 1L))
+        when(imageRepository.findUnclassifiedGoldImages("testuser", SPECIES))
                 .thenReturn(Collections.emptyList());
         when(imageRepository.findRegularImageCandidatesForUser(eq("testuser"), eq(1L), eq(1), any(PageRequest.class)))
                 .thenReturn(List.of(regularImage1));

--- a/backend/src/test/java/com/swipelab/classification/domain/TaskDistributionServiceTest.java
+++ b/backend/src/test/java/com/swipelab/classification/domain/TaskDistributionServiceTest.java
@@ -30,8 +30,7 @@ class TaskDistributionServiceTest {
     @Mock
     private com.swipelab.classification.infrastructure.GoldImageRepository goldImageRepository;
 
-    @Mock
-    private GoldImagePolicy goldImagePolicy;
+
 
     @InjectMocks
     private TaskDistributionService taskDistributionService;
@@ -57,15 +56,14 @@ class TaskDistributionServiceTest {
     }
 
     @Test
-    void getNextImageForUser_ShouldReturnRegularImage() {
-        when(goldImagePolicy.shouldServeGoldImage("testuser", 1L)).thenReturn(false);
+    void getNextRegularImagePair_ShouldReturnRegularImage() {
         when(imageRepository.findRegularImageCandidatesForUser(eq("testuser"), eq(1L), eq(1), any(PageRequest.class)))
                 .thenReturn(List.of(regularImage2));
         when(classificationRepository.findQueriedSpeciesByUsernameAndImageId("testuser", 2L))
                 .thenReturn(Collections.emptyList());
 
         Optional<TaskDistributionService.ImageSpeciesPair> result =
-                taskDistributionService.getNextImageForUser("testuser", 1L, SPECIES);
+                taskDistributionService.getNextRegularImagePair("testuser", 1L, SPECIES);
 
         assertTrue(result.isPresent());
         assertEquals(2L, result.get().image().getId());
@@ -73,8 +71,7 @@ class TaskDistributionServiceTest {
     }
 
     @Test
-    void getNextImageForUser_ShouldReturnGoldImage_WhenPolicySaysGold() {
-        when(goldImagePolicy.shouldServeGoldImage("testuser", 1L)).thenReturn(true);
+    void getNextGoldImagePair_ShouldReturnGoldImage() {
         when(imageRepository.findUnclassifiedGoldImages("testuser", SPECIES))
                 .thenReturn(List.of(goldImage));
         
@@ -83,7 +80,7 @@ class TaskDistributionServiceTest {
         when(goldImageRepository.findByImageIdAndActiveTrue(3L)).thenReturn(Optional.of(mockGoldImage));
 
         Optional<TaskDistributionService.ImageSpeciesPair> result =
-                taskDistributionService.getNextImageForUser("testuser", 1L, SPECIES);
+                taskDistributionService.getNextGoldImagePair("testuser", 1L, SPECIES);
 
         assertTrue(result.isPresent());
         assertEquals(3L, result.get().image().getId());
@@ -91,20 +88,14 @@ class TaskDistributionServiceTest {
     }
 
     @Test
-    void getNextImageForUser_ShouldFallbackToRegularImage_WhenNoGoldAvailable() {
-        when(goldImagePolicy.shouldServeGoldImage("testuser", 1L)).thenReturn(true);
+    void getNextGoldImagePair_ShouldReturnEmpty_WhenNoGoldAvailable() {
         when(imageRepository.findUnclassifiedGoldImages("testuser", SPECIES))
-                .thenReturn(Collections.emptyList());
-        when(imageRepository.findRegularImageCandidatesForUser(eq("testuser"), eq(1L), eq(1), any(PageRequest.class)))
-                .thenReturn(List.of(regularImage1));
-        when(classificationRepository.findQueriedSpeciesByUsernameAndImageId("testuser", 1L))
                 .thenReturn(Collections.emptyList());
 
         Optional<TaskDistributionService.ImageSpeciesPair> result =
-                taskDistributionService.getNextImageForUser("testuser", 1L, SPECIES);
+                taskDistributionService.getNextGoldImagePair("testuser", 1L, SPECIES);
 
-        assertTrue(result.isPresent());
-        assertEquals(1L, result.get().image().getId());
+        assertFalse(result.isPresent());
     }
 
     @Test

--- a/frontend/app/screens/researcher/AddGoldImageScreen.tsx
+++ b/frontend/app/screens/researcher/AddGoldImageScreen.tsx
@@ -67,9 +67,6 @@ export default function AddGoldImageScreen({ navigation }: any) {
         fetchOptions();
     }, []);
 
-    // For demo purposes, using taskId = 1. In production, this would come from navigation params
-    const taskId = 1;
-
     const validateImageUrl = async (url: string): Promise<string | null> => {
         try {
             // Try HEAD first (cheaper), fall back to GET if server doesn't allow HEAD
@@ -140,10 +137,6 @@ export default function AddGoldImageScreen({ navigation }: any) {
     const handleSubmit = async () => {
         setStatusMessage(null);
 
-        if (!taskId) {
-            setStatusMessage({ type: 'error', text: "Task ID is required" });
-            return;
-        }
         if (uploadType === "url" && !imageUrl) {
             setStatusMessage({ type: 'error', text: "Image URL is required" });
             return;
@@ -178,7 +171,6 @@ export default function AddGoldImageScreen({ navigation }: any) {
         }
 
         const formData = new FormData();
-        formData.append("taskId", taskId.toString());
         formData.append("species", species.trim());
         formData.append("correctAnswer", correctAnswer);
 


### PR DESCRIPTION
# PR: Gold Images Refactor, Batch Distribution Fixes, Production Image Reliability, and Credibility Synchronization

## Summary

This PR resolves multiple issues in the Gold Images workflow, including:

* Migrating Gold Images from task-scoped management to global species-based management.
* Fixing gold image injection race conditions and batch starvation issues.
* Ensuring gold images always use their configured species.
* Eliminating production failures caused by local filesystem storage.
* Preventing repeated presentation of previously classified gold images.
* Fixing credibility score synchronization issues caused by asynchronous event timing.
* Adding migration support for historical gold image classifications.

---

## 1. Gold Images Refactored to Global Species-Based Management

### Frontend

#### `AddGoldImageScreen.tsx`

* Removed hardcoded `taskId = 1`.
* Removed task validation requirements.
* Removed `taskId` from upload payloads.

### Backend

#### `Image.java`

* Removed `nullable = false` constraint from `task_id`.

#### `GoldImageController.java`

* Removed `taskId` requirement from upload endpoint.

#### `GoldImageService.java`

* Gold image uploads now create `Image` records with `taskId = null`.

#### `ImageRepository.java`

* Replaced task-based lookup:

  * `findUnclassifiedGoldImages(taskId, userId)`
* With species-based lookup:

  * `findUnclassifiedGoldImages(taskSpecies, userId)`
* Query now joins `GoldImage` and filters by:

  ```sql
  g.species IN :taskSpecies
  ```

#### Researcher Dashboard Compatibility

* Updated `getGoldImagesByTask(...)`.
* Retrieves task species and filters active global gold images accordingly.

#### `TaskDistributionService.java`

* Updated gold image retrieval to use species-based filtering.
* Gold image selection is no longer tied to task ownership.

---

## 2. Gold Image Batch Distribution Fixes

### Problem

Gold image injection relied on an exact modulo calculation that could be skipped due to concurrent batch requests, resulting in inconsistent delivery.

### Changes

#### `GoldImagePolicy.java`

* Renamed:

  * `shouldServeGoldImage(...)`
  * → `shouldIncludeGoldImageInBatch(...)`
* Added `batchSize` parameter.

#### `FrequencyBasedGoldImagePolicy.java`

* Implemented interval-crossing logic.
* Compares:

  * Current interval
  * Next interval after batch retrieval
* Injects a gold image whenever a frequency threshold is crossed within the upcoming batch.

### Result

Gold image frequency is now resilient to concurrent requests and batch fetching behavior.

---

## 3. Batch Starvation Fix

### Problem

Gold image selection logic could repeatedly attempt gold image retrieval inside the batch generation loop, causing starvation and preventing batch completion.

### Solution

#### `ImageService.java`

* Gold image policy evaluation now occurs once before batch generation begins.
* Added:

  ```java
  boolean shouldIncludeGoldImage
  boolean goldImageAdded
  ```
* Exactly one gold image is requested per batch when applicable.
* Remaining slots are filled with regular images.

### Result

* No infinite loops.
* No starvation.
* Predictable batch generation behavior.

---

## 4. Gold Image Species Consistency

### Problem

Gold image questions could be generated using randomly selected species rather than the species configured on the gold image itself.

### Solution

#### `TaskDistributionService.java`

* Fetches the associated `GoldImage` record.
* Uses the actual configured species:

  ```java
  goldImageRepository.findByImageIdAndActiveTrue(...)
  ```

### Result

Gold image prompts always match the configured species.

---

## 5. Production-Safe Gold Image Storage

### Problem

Gold images were stored on local disk.

In distributed environments:

* Upload occurs on Instance A.
* Batch retrieval occurs on Instance B.
* File cannot be found.
* Backend returns fallback image.

Result:

* Blank gold images in production.

### Solution

#### `GoldImageService.java`

* Removed dependency on `FileStorageService`.
* Uploaded files are now:

  * Read directly from `MultipartFile`
  * Converted to Base64
  * Stored in `images.src_path`

#### Remote URLs

* Downloaded during upload.
* Converted to Base64.
* Stored directly in database.

#### Response Mapping

* Returns stored Base64 content directly.
* No filesystem resolution required.

#### `GoldImageController.java`

* Removed:

  ```
  /api/admin/gold-images/{id}/image
  ```
* Endpoint no longer necessary.

### Result

* Gold images are available from any application instance.
* No filesystem dependencies.
* Fully compatible with containerized and load-balanced deployments.

---

## 6. Prevent Repeated Gold Images

### Problem

Gold image classifications were evaluated but not persisted in the `classifications` table.

As a result:

* `findUnclassifiedGoldImages(...)`
* Continued treating previously viewed gold images as unseen.

### Solution

#### `ClassificationService.java`

Updated:

* `submitClassification(...)`
* `submitBatchResponses(...)`

Gold image classifications now:

* Create and persist `Classification` records.
* Behave identically to regular image classifications.

### Result

Users no longer repeatedly receive previously classified gold images.

---

## 7. Credibility Score Synchronization Fix

### Problem

Credibility recalculation was triggered asynchronously before the classification transaction committed.

This caused:

* Stale reads.
* Missed credibility updates.
* Incorrect scores after gold image classification.

### Solution

#### `CredibilityEventListener.java`

Replaced:

```java
@EventListener
```

With:

```java
@TransactionalEventListener(
    phase = TransactionPhase.AFTER_COMMIT
)
```

and executed recalculation within a new transaction.

### Result

Credibility recalculation now occurs only after classification data has been committed and is visible.

---

## 8. Historical Data Migration

### Migration Added

#### `DataMigrationRunner.java`

Startup migration now:

* Scans historical gold image credibility records.
* Creates missing `Classification` records where necessary.
* Prevents previously classified gold images from resurfacing.

### Additional Fix

Added transactional execution to avoid:

```java
LazyInitializationException
```

during application startup when accessing lazy-loaded relationships.

### Result

Existing production data is automatically corrected during deployment.

---

## Testing

### Compilation

* `mvn test-compile`
* `./mvnw clean compile`

### Backend Tests

* `./mvnw clean test`
* All tests passing.

### Test Updates

Updated:

* `GoldImageServiceTest`
* `GoldImageControllerTest`
* `TaskDistributionServiceTest`
* `ImageServiceTest`
* `ClassificationServiceTest`

to reflect:

* Removed task dependencies.
* New repository signatures.
* New gold image policy behavior.
* Classification persistence changes.
* Production image storage changes.

---

## Outcome

This PR fully resolves:

* Gold image task coupling
* Species mismatch issues
* Batch starvation
* Gold image frequency race conditions
* Blank production images
* Repeated gold image presentation
* Credibility synchronization delays
* Historical data inconsistencies

Gold images are now globally managed, production-safe, species-consistent, correctly tracked, and reliably integrated into batch generation and credibility scoring workflows.
