### PR TITLE
added seeding to challenges on production profile

### DIFF
--- a/backend/src/main/java/com/swipelab/config/ChallengeDataSeeder.java
+++ b/backend/src/main/java/com/swipelab/config/ChallengeDataSeeder.java
@@ -1,0 +1,104 @@
+package com.swipelab.config;
+
+import com.swipelab.gamification.badge.BadgeDefinition;
+import com.swipelab.gamification.badge.BadgeDefinitionRepository;
+import com.swipelab.gamification.challenge.AggregationType;
+import com.swipelab.gamification.challenge.ChallengeDefinition;
+import com.swipelab.gamification.challenge.ChallengeDefinitionRepository;
+import com.swipelab.gamification.challenge.MetricType;
+import com.swipelab.gamification.challenge.TimeWindowType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * Seeds the database with default Badge and Challenge definitions.
+ * This runs across all profiles (including production) to ensure
+ * the baseline gamification targets exist in the database.
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class ChallengeDataSeeder implements CommandLineRunner {
+
+    private final BadgeDefinitionRepository badgeDefinitionRepository;
+    private final ChallengeDefinitionRepository challengeDefinitionRepository;
+
+    @Override
+    @Transactional
+    public void run(String... args) {
+        log.info("🌱 Checking Gamification Challenge and Badge Definitions...");
+        seedChallenges();
+    }
+
+    private void seedChallenges() {
+        if (badgeDefinitionRepository.count() == 0) {
+            BadgeDefinition legendBadge = BadgeDefinition.builder()
+                    .title("LabSwiper Legend Badge")
+                    .code("LEGEND_500")
+                    .description("Reach 500 total classifications")
+                    .iconUrl("/badges/legend.png")
+                    .build();
+
+            BadgeDefinition silverBadge = BadgeDefinition.builder()
+                    .title("Silver Badge")
+                    .code("SILVER_DAILY")
+                    .description("Classify 20 images today")
+                    .iconUrl("/badges/silver.png")
+                    .build();
+
+            BadgeDefinition firstSwipeBadge = BadgeDefinition.builder()
+                    .title("First Swipe")
+                    .code("FIRST_SWIPE")
+                    .description("Classify your very first image")
+                    .iconUrl("/badges/first_swipe.png")
+                    .build();
+
+            badgeDefinitionRepository.saveAll(List.of(legendBadge, silverBadge, firstSwipeBadge));
+
+            if (challengeDefinitionRepository.count() == 0) {
+                ChallengeDefinition legendChallenge = ChallengeDefinition.builder()
+                        .name("Reach 500 total classifications")
+                        .description("Lifetime challenge for classifications")
+                        .metricType(MetricType.CLASSIFICATION)
+                        .aggregationType(AggregationType.COUNT)
+                        .targetValue(500)
+                        .timeWindowType(TimeWindowType.LIFETIME)
+                        .badgeId(legendBadge.getId())
+                        .active(true)
+                        .build();
+
+                ChallengeDefinition dailyChallenge = ChallengeDefinition.builder()
+                        .name("Classify 20 images today")
+                        .description("Daily challenge for classifications")
+                        .metricType(MetricType.CLASSIFICATION)
+                        .aggregationType(AggregationType.COUNT)
+                        .targetValue(20)
+                        .timeWindowType(TimeWindowType.DAILY)
+                        .badgeId(silverBadge.getId())
+                        .active(true)
+                        .build();
+
+                ChallengeDefinition firstSwipeChallenge = ChallengeDefinition.builder()
+                        .name("Classify 1 image")
+                        .description("Classify your very first image to earn a badge quickly")
+                        .metricType(MetricType.CLASSIFICATION)
+                        .aggregationType(AggregationType.COUNT)
+                        .targetValue(1)
+                        .timeWindowType(TimeWindowType.LIFETIME)
+                        .badgeId(firstSwipeBadge.getId())
+                        .active(true)
+                        .build();
+
+                challengeDefinitionRepository.saveAll(List.of(legendChallenge, dailyChallenge, firstSwipeChallenge));
+                log.info("✅ Seeded Initial Challenges and Badge Definitions.");
+            }
+        } else {
+            log.info("✅ Challenges and Badges already exist, skipping seed.");
+        }
+    }
+}

--- a/backend/src/main/java/com/swipelab/config/E2eDataSeeder.java
+++ b/backend/src/main/java/com/swipelab/config/E2eDataSeeder.java
@@ -25,13 +25,7 @@ import com.swipelab.users.domain.User;
 import com.swipelab.users.infrastructure.UserRepository;
 import com.swipelab.analytics.domain.*;
 import com.swipelab.analytics.infrastructure.*;
-import com.swipelab.gamification.badge.BadgeDefinition;
-import com.swipelab.gamification.badge.BadgeDefinitionRepository;
-import com.swipelab.gamification.challenge.AggregationType;
-import com.swipelab.gamification.challenge.ChallengeDefinition;
-import com.swipelab.gamification.challenge.ChallengeDefinitionRepository;
-import com.swipelab.gamification.challenge.MetricType;
-import com.swipelab.gamification.challenge.TimeWindowType;
+
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -76,8 +70,6 @@ public class E2eDataSeeder implements CommandLineRunner {
     private final TaskSpeciesStatsRepository taskSpeciesStatsRepository;
     private final TaskDailyStatsRepository taskDailyStatsRepository;
     private final ClassificationFactRepository classificationFactRepository;
-    private final BadgeDefinitionRepository badgeDefinitionRepository;
-    private final ChallengeDefinitionRepository challengeDefinitionRepository;
 
     @Override
     @Transactional
@@ -92,7 +84,6 @@ public class E2eDataSeeder implements CommandLineRunner {
         seedRecipientsAndAssignTasks();
         seedGoldImagesAndClassifications();
         seedAnalytics();
-        seedChallenges();
 
         log.info("✅ E2E Data Seeding complete!");
     }
@@ -473,71 +464,6 @@ public class E2eDataSeeder implements CommandLineRunner {
                 classificationFactRepository.save(fact);
             }
             log.info("Seeded Analytics metrics for Dashboard visibility.");
-        }
-    }
-
-    private void seedChallenges() {
-        if (badgeDefinitionRepository.count() == 0) {
-            BadgeDefinition legendBadge = BadgeDefinition.builder()
-                    .title("LabSwiper Legend Badge")
-                    .code("LEGEND_500")
-                    .description("Reach 500 total classifications")
-                    .iconUrl("/badges/legend.png")
-                    .build();
-
-            BadgeDefinition silverBadge = BadgeDefinition.builder()
-                    .title("Silver Badge")
-                    .code("SILVER_DAILY")
-                    .description("Classify 20 images today")
-                    .iconUrl("/badges/silver.png")
-                    .build();
-
-            BadgeDefinition firstSwipeBadge = BadgeDefinition.builder()
-                    .title("First Swipe")
-                    .code("FIRST_SWIPE")
-                    .description("Classify your very first image")
-                    .iconUrl("/badges/first_swipe.png")
-                    .build();
-
-            badgeDefinitionRepository.saveAll(List.of(legendBadge, silverBadge, firstSwipeBadge));
-
-            if (challengeDefinitionRepository.count() == 0) {
-                ChallengeDefinition legendChallenge = ChallengeDefinition.builder()
-                        .name("Reach 500 total classifications")
-                        .description("Lifetime challenge for classifications")
-                        .metricType(MetricType.CLASSIFICATION)
-                        .aggregationType(AggregationType.COUNT)
-                        .targetValue(500)
-                        .timeWindowType(TimeWindowType.LIFETIME)
-                        .badgeId(legendBadge.getId())
-                        .active(true)
-                        .build();
-
-                ChallengeDefinition dailyChallenge = ChallengeDefinition.builder()
-                        .name("Classify 20 images today")
-                        .description("Daily challenge for classifications")
-                        .metricType(MetricType.CLASSIFICATION)
-                        .aggregationType(AggregationType.COUNT)
-                        .targetValue(20)
-                        .timeWindowType(TimeWindowType.DAILY)
-                        .badgeId(silverBadge.getId())
-                        .active(true)
-                        .build();
-
-                ChallengeDefinition firstSwipeChallenge = ChallengeDefinition.builder()
-                        .name("Classify 1 image")
-                        .description("Classify your very first image to earn a badge quickly")
-                        .metricType(MetricType.CLASSIFICATION)
-                        .aggregationType(AggregationType.COUNT)
-                        .targetValue(1)
-                        .timeWindowType(TimeWindowType.LIFETIME)
-                        .badgeId(firstSwipeBadge.getId())
-                        .active(true)
-                        .build();
-
-                challengeDefinitionRepository.saveAll(List.of(legendChallenge, dailyChallenge, firstSwipeChallenge));
-                log.info("Seeded Challenges and Badge Definitions.");
-            }
         }
     }
 }

--- a/backend/src/main/java/com/swipelab/config/MockDataSeeder.java
+++ b/backend/src/main/java/com/swipelab/config/MockDataSeeder.java
@@ -25,13 +25,7 @@ import com.swipelab.users.domain.User;
 import com.swipelab.users.infrastructure.UserRepository;
 import com.swipelab.analytics.domain.*;
 import com.swipelab.analytics.infrastructure.*;
-import com.swipelab.gamification.badge.BadgeDefinition;
-import com.swipelab.gamification.badge.BadgeDefinitionRepository;
-import com.swipelab.gamification.challenge.AggregationType;
-import com.swipelab.gamification.challenge.ChallengeDefinition;
-import com.swipelab.gamification.challenge.ChallengeDefinitionRepository;
-import com.swipelab.gamification.challenge.MetricType;
-import com.swipelab.gamification.challenge.TimeWindowType;
+
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -74,8 +68,6 @@ public class MockDataSeeder implements CommandLineRunner {
     private final TaskSpeciesStatsRepository taskSpeciesStatsRepository;
     private final TaskDailyStatsRepository taskDailyStatsRepository;
     private final ClassificationFactRepository classificationFactRepository;
-    private final BadgeDefinitionRepository badgeDefinitionRepository;
-    private final ChallengeDefinitionRepository challengeDefinitionRepository;
 
     @Override
     @Transactional
@@ -90,7 +82,6 @@ public class MockDataSeeder implements CommandLineRunner {
         seedRecipientsAndAssignTasks();
         seedGoldImagesAndClassifications();
         seedAnalytics();
-        seedChallenges();
 
         log.info("✅ Mock Data Seeding complete!");
     }
@@ -383,71 +374,6 @@ public class MockDataSeeder implements CommandLineRunner {
                 classificationFactRepository.save(fact);
             }
             log.info("Seeded Analytics metrics for Dashboard visibility.");
-        }
-    }
-
-    private void seedChallenges() {
-        if (badgeDefinitionRepository.count() == 0) {
-            BadgeDefinition legendBadge = BadgeDefinition.builder()
-                    .title("LabSwiper Legend Badge")
-                    .code("LEGEND_500")
-                    .description("Reach 500 total classifications")
-                    .iconUrl("/badges/legend.png")
-                    .build();
-
-            BadgeDefinition silverBadge = BadgeDefinition.builder()
-                    .title("Silver Badge")
-                    .code("SILVER_DAILY")
-                    .description("Classify 20 images today")
-                    .iconUrl("/badges/silver.png")
-                    .build();
-
-            BadgeDefinition firstSwipeBadge = BadgeDefinition.builder()
-                    .title("First Swipe")
-                    .code("FIRST_SWIPE")
-                    .description("Classify your very first image")
-                    .iconUrl("/badges/first_swipe.png")
-                    .build();
-
-            badgeDefinitionRepository.saveAll(List.of(legendBadge, silverBadge, firstSwipeBadge));
-
-            if (challengeDefinitionRepository.count() == 0) {
-                ChallengeDefinition legendChallenge = ChallengeDefinition.builder()
-                        .name("Reach 500 total classifications")
-                        .description("Lifetime challenge for classifications")
-                        .metricType(MetricType.CLASSIFICATION)
-                        .aggregationType(AggregationType.COUNT)
-                        .targetValue(500)
-                        .timeWindowType(TimeWindowType.LIFETIME)
-                        .badgeId(legendBadge.getId())
-                        .active(true)
-                        .build();
-
-                ChallengeDefinition dailyChallenge = ChallengeDefinition.builder()
-                        .name("Classify 20 images today")
-                        .description("Daily challenge for classifications")
-                        .metricType(MetricType.CLASSIFICATION)
-                        .aggregationType(AggregationType.COUNT)
-                        .targetValue(20)
-                        .timeWindowType(TimeWindowType.DAILY)
-                        .badgeId(silverBadge.getId())
-                        .active(true)
-                        .build();
-
-                ChallengeDefinition firstSwipeChallenge = ChallengeDefinition.builder()
-                        .name("Classify 1 image")
-                        .description("Classify your very first image to earn a badge quickly")
-                        .metricType(MetricType.CLASSIFICATION)
-                        .aggregationType(AggregationType.COUNT)
-                        .targetValue(1)
-                        .timeWindowType(TimeWindowType.LIFETIME)
-                        .badgeId(firstSwipeBadge.getId())
-                        .active(true)
-                        .build();
-
-                challengeDefinitionRepository.saveAll(List.of(legendChallenge, dailyChallenge, firstSwipeChallenge));
-                log.info("Seeded Challenges and Badge Definitions.");
-            }
         }
     }
 }


### PR DESCRIPTION
Here is what I did:

1. **Created `ChallengeDataSeeder.java`**: 
   I created a new universal `CommandLineRunner` in `com.swipelab.config.ChallengeDataSeeder`. Because it does not have a `@Profile` annotation, it will run in all environments (including production). On startup, it checks if `badgeDefinitionRepository.count() == 0`, and if so, it seeds the initial three default badges ("LabSwiper Legend Badge", "Silver Badge", "First Swipe") and their corresponding challenges.
   
2. **Deduplicated Seeders**:
   I removed the `seedChallenges()` method, unused imports, and `ChallengeDefinitionRepository` / `BadgeDefinitionRepository` fields from both `MockDataSeeder.java` and `E2eDataSeeder.java`. Now, gamification configuration is centrally handled in one place, preventing any duplicate insertions or conflicting logic across different environments.

Since you are running the Spring Boot backend currently (`./mvnw spring-boot:run` has been running for ~9 minutes), the application won't automatically pick up these changes since it might not be running in a hot-reload mode. 

On its next startup, the `ChallengeDataSeeder` will execute and inject the challenges into your database, which will immediately cause the mobile app `ChallengesScreen` to start working correctly under the `production` profile