### PR TITLE
Security Audit Remediation (#204)

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -30,7 +30,7 @@ Architecture: Modular Hexagonal/DDD.
 * Backend/Testing: Configured E2E testing environment to use dynamic local test crops (`e2e-crops`) inside MockStardbiClient by generating globally unique mock `external_box_id`s on the fly, preventing database constraint conflicts during manual UI task creation.
 * Backend: Fixed task image count display in `TasksManagementScreen` (Issue #222). Replaced hardcoded zeros in `TaskMapper` by injecting `ImageRepository` and `ClassificationRepository` into `TaskService` to query real task image totals and distinct classified image counts.
 * Testing: Created `tests/e2e/researcher/dashboard.spec.ts` to verify the researcher View Dashboard flow, checking the task list, progress bars, and task details screen assertions.
-
+* Security: Remediated Medium severity security findings (secured Swagger UI in production, sanitized global exception handler, downgraded JWT logging, and unified login error messages).
 ## Current Focus (Active GitHub Issues)
 * Issue #201: Refactor Backend roles to include Researchers and Super Admin.
 * Issue #226: [Frontend] fix recipients list not deleting users.

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -150,6 +150,13 @@
 			<artifactId>caffeine</artifactId>
 		</dependency>
 
+		<!-- Rate Limiting: Bucket4j token-bucket algorithm (uses Caffeine as the store) -->
+		<dependency>
+			<groupId>com.bucket4j</groupId>
+			<artifactId>bucket4j-core</artifactId>
+			<version>8.10.1</version>
+		</dependency>
+
 		<!-- Awaitility: polling helper used in integration tests -->
 		<dependency>
 			<groupId>org.awaitility</groupId>

--- a/backend/src/main/java/com/swipelab/auth/api/AuthController.java
+++ b/backend/src/main/java/com/swipelab/auth/api/AuthController.java
@@ -264,12 +264,14 @@ public class AuthController {
     }
 
     /**
-     * Send an invitation email to a new admin or researcher
+     * Send an invitation email to a new admin or researcher.
+     * Restricted to the Super Admin — uses the same SpEL bean check
+     * as all other privileged endpoints in this application.
      *
      * Endpoint: POST /api/v1/auth/invitation/admin
      */
     @PostMapping("/invitation/admin")
-    // @org.springframework.security.access.prepost.PreAuthorize("hasRole('ADMIN')")
+    @org.springframework.security.access.prepost.PreAuthorize("@securityAuthorizationService.isSuperAdmin(authentication.name)")
     public ResponseEntity<Map<String, String>> inviteAdmin(
             @Valid @RequestBody InviteAdminRequest request) {
 

--- a/backend/src/main/java/com/swipelab/auth/api/AuthController.java
+++ b/backend/src/main/java/com/swipelab/auth/api/AuthController.java
@@ -16,6 +16,8 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.beans.factory.annotation.Value;
 import com.swipelab.users.domain.User;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
 
 import java.security.Principal;
 import java.util.HashMap;
@@ -27,11 +29,11 @@ import java.util.Map;
 public class AuthController {
 
     private final AuthenticationService authenticationService;
-
     private final UserService userService;
     private final com.swipelab.auth.application.OAuth2Service oAuth2Service;
     private final com.swipelab.auth.domain.AuthMapper authMapper;
     private final com.swipelab.auth.application.JwtService jwtService;
+    private final SpringTemplateEngine templateEngine;
 
     /**
      * Register a new user
@@ -61,28 +63,30 @@ public class AuthController {
     private String frontendUrl;
 
     /**
-     * Verify user email with token via browser GET (Link clicked in email)
+     * Verify user email with token via browser GET (link clicked in email).
+     *
+     * Security: previously used raw string concatenation of frontendUrl and e.getMessage()
+     * into HTML, creating a Reflected XSS vector. Now uses Thymeleaf templates where all
+     * dynamic values are rendered via th:text (auto-escaped) or safe data attributes.
+     * The raw exception message is never forwarded to the client.
      */
     @GetMapping(value = "/verify-email", produces = org.springframework.http.MediaType.TEXT_HTML_VALUE)
     public String verifyEmailLink(@RequestParam String token) {
+        Context ctx = new Context();
         try {
             authenticationService.verifyEmail(token);
-            return "<html><head><meta http-equiv=\"refresh\" content=\"5;url=" + frontendUrl + "\" /></head>" +
-                   "<body style='font-family:sans-serif; text-align:center; padding-top: 50px; background-color: #f4f6f9;'>" +
-                   "<div style='max-width: 600px; margin: 0 auto; background: white; padding: 40px; border-radius: 8px; box-shadow: 0 4px 6px rgba(0,0,0,0.1);'>" +
-                   "<h2 style='color: #4B7BE5;'>Email Verified Successfully! <br>&#10004;</h2>" +
-                   "<p style='font-size: 16px; color: #333;'>Your account is now fully active.</p>" +
-                   "<p style='font-size: 16px; color: #666;'>You will be redirected back to the app to log in shortly.</p>" +
-                   "<p style='font-size: 14px; color: #999; margin-top: 20px;'>Redirecting in <span id='countdown'>5</span> seconds...</p>" +
-                   "<script>var time=5; setInterval(function(){ if(time>0){time--; document.getElementById('countdown').innerText=time;} if(time===0){time--; window.location.href='" + frontendUrl + "';} }, 1000);</script>" +
-                   "</div></body></html>";
+            // frontendUrl is a server-side config value, not user input.
+            // Rendered into a data attribute via th:data-url so the redirect
+            // JS never uses string concatenation into the page source.
+            ctx.setVariable("frontendUrl", frontendUrl);
+            return templateEngine.process("auth/email-verify-success", ctx);
         } catch (Exception e) {
-            return "<html><body style='font-family:sans-serif; text-align:center; padding-top: 50px; background-color: #f4f6f9;'>" +
-                   "<div style='max-width: 600px; margin: 0 auto; background: white; padding: 40px; border-radius: 8px; box-shadow: 0 4px 6px rgba(0,0,0,0.1);'>" +
-                   "<h2 style='color: #E11D48;'>Verification Failed &#10006;</h2>" +
-                   "<p style='font-size: 16px; color: #333;'>" + e.getMessage() + "</p>" +
-                   "<p style='font-size: 16px; color: #666;'>Please try registering again or contact support.</p>" +
-                   "</div></body></html>";
+            // Log the full exception server-side; only a generic category
+            // is surfaced to the client — never the raw exception message.
+            org.slf4j.LoggerFactory.getLogger(getClass())
+                    .warn("Email verification failed for token [{}]: {}", token, e.getMessage());
+            ctx.setVariable("errorMessage", "The verification link is invalid or has expired.");
+            return templateEngine.process("auth/email-verify-failure", ctx);
         }
     }
 

--- a/backend/src/main/java/com/swipelab/auth/application/AuthenticationService.java
+++ b/backend/src/main/java/com/swipelab/auth/application/AuthenticationService.java
@@ -168,7 +168,7 @@ public class AuthenticationService {
     public AuthResponse login(LoginRequest request) {
         String normalizedUsername = request.getUsername().toLowerCase().trim();
         User user = userRepository.findByUsername(normalizedUsername)
-                .orElseThrow(() -> new UnauthorizedException("User not exists"));
+                .orElseThrow(() -> new UnauthorizedException("Invalid username or password"));
 
         // Account state checks
         if (!Boolean.TRUE.equals(user.getActive()) ||
@@ -184,7 +184,7 @@ public class AuthenticationService {
         // Password validation
         if (user.getPasswordHash() == null ||
                 !passwordEncoder.matches(request.getPassword(), user.getPasswordHash())) {
-            throw new UnauthorizedException("Wrong password");
+            throw new UnauthorizedException("Invalid username or password");
         }
 
         // Generate tokens — set lastLogin first so generateRefreshToken saves both in one UPDATE

--- a/backend/src/main/java/com/swipelab/auth/infrastructure/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/swipelab/auth/infrastructure/JwtAuthenticationFilter.java
@@ -33,7 +33,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             if (StringUtils.hasText(jwt)) {
                 if (tokenProvider.isTokenValid(jwt)) {
                     String username = tokenProvider.extractUsername(jwt);
-                    logger.info("VALID Token for user: " + username);
+                    // MED-03: Downgrade valid token log to debug to prevent log bloat
+                    logger.debug("VALID Token for user: " + username);
 
                     UserDetails userDetails = userDetailsService.loadUserByUsername(username);
                     UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
@@ -44,7 +45,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
                     SecurityContextHolder.getContext().setAuthentication(authentication);
                 } else {
-                    logger.debug("INVALID or EXPIRED JWT Token (may be an external stardbi token): " + jwt);
+                    // MED-03: Remove the plaintext token from the log message
+                    logger.debug("INVALID or EXPIRED JWT Token encountered");
                 }
             } else {
                 logger.debug("No JWT Token found in the request headers");

--- a/backend/src/main/java/com/swipelab/auth/infrastructure/RateLimitingFilter.java
+++ b/backend/src/main/java/com/swipelab/auth/infrastructure/RateLimitingFilter.java
@@ -46,19 +46,19 @@ public class RateLimitingFilter extends OncePerRequestFilter {
     /** Maps a URI suffix to a bandwidth limit definition. */
     private static final Map<String, Bandwidth> LIMITS = Map.of(
             "/api/v1/auth/login",
-            Bandwidth.classic(5, Refill.intervally(5, Duration.ofMinutes(1))),
+            Bandwidth.classic(20, Refill.intervally(20, Duration.ofMinutes(1))),
 
             "/api/v1/auth/register",
-            Bandwidth.classic(3, Refill.intervally(3, Duration.ofMinutes(15))),
+            Bandwidth.classic(10, Refill.intervally(10, Duration.ofMinutes(15))),
 
             "/api/v1/auth/password/forgot",
-            Bandwidth.classic(3, Refill.intervally(3, Duration.ofHours(1))),
+            Bandwidth.classic(10, Refill.intervally(10, Duration.ofHours(1))),
 
             "/api/v1/auth/email/resend",
-            Bandwidth.classic(3, Refill.intervally(3, Duration.ofHours(1))),
+            Bandwidth.classic(10, Refill.intervally(10, Duration.ofHours(1))),
 
             "/api/v1/auth/invitation/admin",
-            Bandwidth.classic(5, Refill.intervally(5, Duration.ofHours(1)))
+            Bandwidth.classic(10, Refill.intervally(10, Duration.ofHours(1)))
     );
 
     /**

--- a/backend/src/main/java/com/swipelab/auth/infrastructure/RateLimitingFilter.java
+++ b/backend/src/main/java/com/swipelab/auth/infrastructure/RateLimitingFilter.java
@@ -1,0 +1,126 @@
+package com.swipelab.auth.infrastructure;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.Refill;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * IP-based rate limiter for authentication endpoints using Bucket4j
+ * token-bucket algorithm backed by a Caffeine in-process cache.
+ *
+ * Why a filter and not an aspect/annotation?
+ *  - Filters run before the DispatcherServlet, so they protect against
+ *    abusive clients without consuming any Spring context resources.
+ *  - This keeps the controllers clean and the limit logic centralised.
+ *
+ * Limits (configurable via the LIMITS map):
+ *  - /login:            5 requests per minute
+ *  - /register:         3 requests per 15 minutes
+ *  - /password/forgot:  3 requests per hour  (email bombing prevention)
+ *  - /email/resend:     3 requests per hour  (email bombing prevention)
+ *  - /invitation/admin: 5 requests per hour
+ *
+ * Cache TTL: 2 hours — buckets are evicted after 2h of inactivity, so a
+ * persistent attacker cannot indefinitely grow the cache.
+ */
+@Slf4j
+@Component
+public class RateLimitingFilter extends OncePerRequestFilter {
+
+    /** Maps a URI suffix to a bandwidth limit definition. */
+    private static final Map<String, Bandwidth> LIMITS = Map.of(
+            "/api/v1/auth/login",
+            Bandwidth.classic(5, Refill.intervally(5, Duration.ofMinutes(1))),
+
+            "/api/v1/auth/register",
+            Bandwidth.classic(3, Refill.intervally(3, Duration.ofMinutes(15))),
+
+            "/api/v1/auth/password/forgot",
+            Bandwidth.classic(3, Refill.intervally(3, Duration.ofHours(1))),
+
+            "/api/v1/auth/email/resend",
+            Bandwidth.classic(3, Refill.intervally(3, Duration.ofHours(1))),
+
+            "/api/v1/auth/invitation/admin",
+            Bandwidth.classic(5, Refill.intervally(5, Duration.ofHours(1)))
+    );
+
+    /**
+     * Cache key: "<client-ip>:<request-uri>".
+     * TTL of 2 h ensures that an idle attacker's bucket is evicted while still
+     * providing a generous window for legitimate session gaps.
+     */
+    private final Cache<String, Bucket> bucketCache = Caffeine.newBuilder()
+            .expireAfterAccess(2, TimeUnit.HOURS)
+            .maximumSize(10_000)
+            .build();
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain chain)
+            throws ServletException, IOException {
+
+        String uri = request.getRequestURI();
+        Bandwidth limit = LIMITS.get(uri);
+
+        // Only rate-limit the endpoints listed in LIMITS; pass everything else through.
+        if (limit == null) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        String clientIp = resolveClientIp(request);
+        String cacheKey = clientIp + ":" + uri;
+
+        Bucket bucket = bucketCache.get(cacheKey, k -> Bucket.builder()
+                .addLimit(limit)
+                .build());
+
+        if (bucket.tryConsume(1)) {
+            chain.doFilter(request, response);
+        } else {
+            log.warn("Rate limit exceeded for IP={} on URI={}", clientIp, uri);
+            rejectRequest(response);
+        }
+    }
+
+    /**
+     * Resolve the real client IP, respecting X-Forwarded-For when behind a
+     * reverse proxy (Nginx / Docker / cloud load balancer).
+     * Only the first IP in the forwarded chain is used to prevent spoofing via
+     * a crafted multi-hop XFF header.
+     */
+    private String resolveClientIp(HttpServletRequest request) {
+        String xff = request.getHeader("X-Forwarded-For");
+        if (xff != null && !xff.isBlank()) {
+            return xff.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
+    }
+
+    private void rejectRequest(HttpServletResponse response) throws IOException {
+        response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.getWriter().write(
+                "{\"error\":\"Too Many Requests\"," +
+                "\"message\":\"Rate limit exceeded. Please slow down and try again later.\"}"
+        );
+    }
+}

--- a/backend/src/main/java/com/swipelab/auth/infrastructure/SecurityConfig.java
+++ b/backend/src/main/java/com/swipelab/auth/infrastructure/SecurityConfig.java
@@ -75,17 +75,24 @@ public class SecurityConfig {
                                                                 "/",
                                                                 "/error",
                                                                 "/favicon.ico",
-                                                                "/api/v1/auth/**",
-                                                                "/auth/**",
+                                                                // Auth endpoints (strictly matched)
+                                                                "/api/v1/auth/login",
+                                                                "/api/v1/auth/register",
+                                                                "/api/v1/auth/refresh",
+                                                                "/api/v1/auth/password/forgot",
+                                                                "/api/v1/auth/password/reset",
+                                                                "/api/v1/auth/email/verify",
+                                                                "/api/v1/auth/email/resend",
+                                                                "/api/v1/auth/login/google",
+                                                                "/api/v1/auth/external/stardbi/loginExternal",
+                                                                "/api/v1/auth/verify-email", // HTML view endpoint
+                                                                // System and Swagger
                                                                 "/oauth2/**",
                                                                 "/login/**",
                                                                 "/v3/api-docs/**",
                                                                 "/swagger-ui/**",
-                                                                "/swipelab/**",
-                                                                "/swipe_lab/**",
-                                                                "/api/v1/system/**",
                                                                 "/swagger-ui.html",
-                                                                "/stardbi/**",
+                                                                "/stardbi/**", // Mock stardbi (usually for dev only)
                                                                 "/api/admin/gold-images/*/image",
                                                                 "/api/v1/images/*/content")
                                                 .permitAll()

--- a/backend/src/main/java/com/swipelab/auth/infrastructure/SecurityConfig.java
+++ b/backend/src/main/java/com/swipelab/auth/infrastructure/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.swipelab.auth.infrastructure;
 import com.swipelab.auth.infrastructure.CustomOAuth2UserService;
 import com.swipelab.auth.infrastructure.JwtAuthenticationFilter;
 import com.swipelab.auth.infrastructure.BannedUserFilter;
+import com.swipelab.auth.infrastructure.RateLimitingFilter;
 import com.swipelab.auth.external.ExternalAuthFilter;
 import com.swipelab.auth.infrastructure.OAuth2AuthenticationFailureHandler;
 import com.swipelab.auth.infrastructure.OAuth2AuthenticationSuccessHandler;
@@ -46,6 +47,9 @@ public class SecurityConfig {
 
         @Autowired
         private BannedUserFilter bannedUserFilter;
+
+        @Autowired
+        private RateLimitingFilter rateLimitingFilter;
 
         @Value("${cors.allowed-origins}")
         private String allowedOrigins;
@@ -97,7 +101,10 @@ public class SecurityConfig {
                                                                 .baseUri("/oauth2/callback/**"))
                                                 .successHandler(oAuth2AuthenticationSuccessHandler)
                                                 .failureHandler(oAuth2AuthenticationFailureHandler))
+                                // JWT filter must be added first so it can be used as an anchor
                                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                                // Rate limiting runs first — reject abusive IPs before any token work
+                                .addFilterBefore(rateLimitingFilter, JwtAuthenticationFilter.class)
                                 .addFilterAfter(externalAuthFilter, JwtAuthenticationFilter.class)
                                 // Ban check runs last — after both auth filters have set the SecurityContext
                                 .addFilterAfter(bannedUserFilter, ExternalAuthFilter.class);

--- a/backend/src/main/java/com/swipelab/auth/infrastructure/SecurityConfig.java
+++ b/backend/src/main/java/com/swipelab/auth/infrastructure/SecurityConfig.java
@@ -51,6 +51,9 @@ public class SecurityConfig {
         @Autowired
         private RateLimitingFilter rateLimitingFilter;
 
+        @Autowired
+        private org.springframework.core.env.Environment env;
+
         @Value("${cors.allowed-origins}")
         private String allowedOrigins;
 
@@ -70,8 +73,8 @@ public class SecurityConfig {
                                                 }))
                                 .sessionManagement(session -> session
                                                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                                .authorizeHttpRequests(auth -> auth
-                                                .requestMatchers(
+                                .authorizeHttpRequests(auth -> {
+                                        auth.requestMatchers(
                                                                 "/",
                                                                 "/error",
                                                                 "/favicon.ico",
@@ -89,16 +92,24 @@ public class SecurityConfig {
                                                                 // System and Swagger
                                                                 "/oauth2/**",
                                                                 "/login/**",
-                                                                "/v3/api-docs/**",
-                                                                "/swagger-ui/**",
-                                                                "/swagger-ui.html",
                                                                 "/stardbi/**", // Mock stardbi (usually for dev only)
                                                                 "/api/admin/gold-images/*/image",
-                                                                "/api/v1/images/*/content")
-                                                .permitAll()
-                                                .requestMatchers(org.springframework.http.HttpMethod.OPTIONS, "/**")
-                                                .permitAll()
-                                                .anyRequest().authenticated())
+                                                                "/api/v1/images/*/content"
+                                                ).permitAll();
+
+                                        // MED-01: Expose Swagger UI only in non-prod environments
+                                        if (!Arrays.asList(env.getActiveProfiles()).contains("prod")) {
+                                                auth.requestMatchers(
+                                                        "/v3/api-docs/**",
+                                                        "/swagger-ui/**",
+                                                        "/swagger-ui.html"
+                                                ).permitAll();
+                                        }
+
+                                        auth.requestMatchers(org.springframework.http.HttpMethod.OPTIONS, "/**")
+                                                        .permitAll()
+                                                        .anyRequest().authenticated();
+                                })
                                 .oauth2Login(oauth2 -> oauth2
                                                 .userInfoEndpoint(userInfo -> userInfo
                                                                 .userService(customOAuth2UserService))

--- a/backend/src/main/java/com/swipelab/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/swipelab/exception/GlobalExceptionHandler.java
@@ -135,11 +135,15 @@ public class GlobalExceptionHandler {
         public ResponseEntity<ErrorResponse> handleGlobalException(
                         Exception ex, HttpServletRequest request) {
 
+                // MED-02: Log the full exception server-side so it's not lost
+                log.error("Unhandled exception occurred during request to {}: ", request.getRequestURI(), ex);
+
+                // Return a generic message to the client to prevent information disclosure
                 ErrorResponse errorResponse = ErrorResponse.builder()
                                 .timestamp(LocalDateTime.now())
                                 .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
                                 .error("Internal Server Error")
-                                .message(ex.getMessage())
+                                .message("An unexpected internal server error occurred")
                                 .path(request.getRequestURI())
                                 .build();
 

--- a/backend/src/main/java/com/swipelab/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/swipelab/exception/GlobalExceptionHandler.java
@@ -8,11 +8,13 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import lombok.extern.slf4j.Slf4j;
 
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
+@Slf4j
 @ControllerAdvice
 public class GlobalExceptionHandler {
 

--- a/backend/src/main/java/com/swipelab/integration/stardbi/SyncController.java
+++ b/backend/src/main/java/com/swipelab/integration/stardbi/SyncController.java
@@ -3,6 +3,7 @@ package com.swipelab.integration.stardbi;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,6 +18,7 @@ public class SyncController {
 
     private final StardbiSyncService stardbiSyncService;
 
+    @PreAuthorize("@securityAuthorizationService.isSuperAdmin(authentication.name)")
     @PostMapping("/sync-stardbi")
     public ResponseEntity<String> forceSyncStardbi() {
         log.info("Manual Stardbi sync triggered via REST API");

--- a/backend/src/main/resources/templates/auth/email-verify-failure.html
+++ b/backend/src/main/resources/templates/auth/email-verify-failure.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Verification Failed — SwipeLab</title>
+    <style>
+        body { font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; background-color: #f4f6f9; color: #333; margin: 0; padding: 0; }
+        .container { max-width: 600px; margin: 60px auto; background: #fff; padding: 40px; border-radius: 10px; box-shadow: 0 4px 12px rgba(0,0,0,0.08); text-align: center; }
+        h2 { color: #E11D48; font-size: 24px; margin-bottom: 12px; }
+        p  { font-size: 16px; color: #555; margin: 8px 0; }
+        .error-msg { color: #777; font-size: 14px; margin-top: 12px; font-style: italic; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h2>Verification Failed &#10006;</h2>
+        <!--
+            th:text auto-escapes all HTML special characters, eliminating XSS.
+            errorMessage contains only the sanitized error type (not the raw exception).
+        -->
+        <p class="error-msg" th:text="${errorMessage}">Verification link is invalid or has expired.</p>
+        <p>Please try registering again or contact support.</p>
+    </div>
+</body>
+</html>

--- a/backend/src/main/resources/templates/auth/email-verify-success.html
+++ b/backend/src/main/resources/templates/auth/email-verify-success.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Email Verified — SwipeLab</title>
+    <style>
+        body { font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; background-color: #f4f6f9; color: #333; margin: 0; padding: 0; }
+        .container { max-width: 600px; margin: 60px auto; background: #fff; padding: 40px; border-radius: 10px; box-shadow: 0 4px 12px rgba(0,0,0,0.08); text-align: center; }
+        h2 { color: #4B7BE5; font-size: 24px; margin-bottom: 12px; }
+        p  { font-size: 16px; color: #555; margin: 8px 0; }
+        .redirect-note { font-size: 14px; color: #999; margin-top: 20px; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h2>Email Verified Successfully! &#10004;</h2>
+        <p>Your account is now fully active.</p>
+        <p>You will be redirected back to the app to log in shortly.</p>
+        <p class="redirect-note">Redirecting in <span id="countdown">5</span> seconds&hellip;</p>
+    </div>
+    <!-- frontendUrl is server-controlled config; th:href auto-encodes it -->
+    <meta id="redirect-target" th:data-url="${frontendUrl}" />
+    <script>
+        var target = document.getElementById('redirect-target').getAttribute('data-url');
+        var time = 5;
+        var el = document.getElementById('countdown');
+        setInterval(function () {
+            if (time > 0) { time--; el.textContent = time; }
+            if (time === 0) { time--; window.location.href = target; }
+        }, 1000);
+    </script>
+</body>
+</html>

--- a/backend/src/test/java/com/swipelab/auth/api/AuthControllerTest.java
+++ b/backend/src/test/java/com/swipelab/auth/api/AuthControllerTest.java
@@ -25,8 +25,11 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.thymeleaf.context.IContext;
+import org.thymeleaf.spring6.SpringTemplateEngine;
 
 import java.security.Principal;
 import java.util.Collections;
@@ -34,6 +37,7 @@ import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -58,6 +62,9 @@ class AuthControllerTest {
     @Mock
     private JwtService jwtService;
 
+    @Mock
+    private SpringTemplateEngine templateEngine;
+
     @InjectMocks
     private AuthController authController;
 
@@ -69,6 +76,8 @@ class AuthControllerTest {
                 .setCustomArgumentResolvers(new AuthenticationPrincipalArgumentResolver())
                 .build();
         objectMapper = new ObjectMapper();
+        // Inject @Value field that cannot be set by @InjectMocks alone
+        ReflectionTestUtils.setField(authController, "frontendUrl", "http://localhost:3000");
     }
 
     @Test
@@ -296,5 +305,45 @@ class AuthControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest());
+    }
+
+    // ── HIGH-02: verifyEmailLink XSS fix tests ────────────────────────────────
+
+    @Test
+    void verifyEmailLink_ShouldRenderSuccessTemplate_WhenTokenIsValid() throws Exception {
+        doNothing().when(authenticationService).verifyEmail("valid-token");
+        when(templateEngine.process(eq("auth/email-verify-success"), any(IContext.class)))
+                .thenReturn("<html><body>Email Verified Successfully!</body></html>");
+
+        mockMvc.perform(get("/api/v1/auth/verify-email")
+                        .param("token", "valid-token"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(org.springframework.http.MediaType.TEXT_HTML))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("Email Verified Successfully!")));
+
+        verify(authenticationService, times(1)).verifyEmail("valid-token");
+        verify(templateEngine, times(1)).process(eq("auth/email-verify-success"), any(IContext.class));
+    }
+
+    @Test
+    void verifyEmailLink_ShouldRenderFailureTemplate_AndNeverLeakExceptionMessage() throws Exception {
+        String rawExceptionMessage = "<script>alert('XSS')</script>";
+        doThrow(new RuntimeException(rawExceptionMessage))
+                .when(authenticationService).verifyEmail("bad-token");
+        when(templateEngine.process(eq("auth/email-verify-failure"), any(IContext.class)))
+                .thenReturn("<html><body>The verification link is invalid or has expired.</body></html>");
+
+        String responseBody = mockMvc.perform(get("/api/v1/auth/verify-email")
+                        .param("token", "bad-token"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(org.springframework.http.MediaType.TEXT_HTML))
+                .andReturn().getResponse().getContentAsString();
+
+        // The raw exception message must NEVER appear in the response
+        org.assertj.core.api.Assertions.assertThat(responseBody)
+                .doesNotContain(rawExceptionMessage)
+                .contains("invalid or has expired");
+
+        verify(templateEngine, times(1)).process(eq("auth/email-verify-failure"), any(IContext.class));
     }
 }

--- a/backend/src/test/java/com/swipelab/auth/api/AuthControllerTest.java
+++ b/backend/src/test/java/com/swipelab/auth/api/AuthControllerTest.java
@@ -72,12 +72,18 @@ class AuthControllerTest {
 
     @BeforeEach
     void setUp() {
+        SecurityContextHolder.clearContext();
         mockMvc = MockMvcBuilders.standaloneSetup(authController)
                 .setCustomArgumentResolvers(new AuthenticationPrincipalArgumentResolver())
                 .build();
         objectMapper = new ObjectMapper();
         // Inject @Value field that cannot be set by @InjectMocks alone
         ReflectionTestUtils.setField(authController, "frontendUrl", "http://localhost:3000");
+    }
+
+    @org.junit.jupiter.api.AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
     }
 
     @Test

--- a/backend/src/test/java/com/swipelab/auth/api/InviteAdminSecurityTest.java
+++ b/backend/src/test/java/com/swipelab/auth/api/InviteAdminSecurityTest.java
@@ -120,13 +120,13 @@ class InviteAdminSecurityTest {
 
     @Test
     @WithAnonymousUser
-    @DisplayName("anonymous caller is rejected with 403")
+    @DisplayName("anonymous caller is rejected with 401")
     void anonymousCaller_isRejected() throws Exception {
         mockMvc.perform(post(ENDPOINT)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(validBody())
                         .with(csrf()))
-                .andExpect(status().isForbidden());
+                .andExpect(status().isUnauthorized());
 
         verify(authenticationService, never()).inviteAdmin(any());
     }

--- a/backend/src/test/java/com/swipelab/auth/api/InviteAdminSecurityTest.java
+++ b/backend/src/test/java/com/swipelab/auth/api/InviteAdminSecurityTest.java
@@ -1,0 +1,174 @@
+package com.swipelab.auth.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.swipelab.auth.application.AuthenticationService;
+import com.swipelab.auth.application.JwtService;
+import com.swipelab.auth.application.OAuth2Service;
+import com.swipelab.auth.application.SecurityAuthorizationService;
+import com.swipelab.auth.domain.AuthMapper;
+import com.swipelab.auth.external.ExternalAuthFilter;
+import com.swipelab.auth.infrastructure.BannedUserFilter;
+import com.swipelab.auth.infrastructure.CustomOAuth2UserService;
+import com.swipelab.auth.infrastructure.JwtAuthenticationFilter;
+import com.swipelab.auth.infrastructure.OAuth2AuthenticationFailureHandler;
+import com.swipelab.auth.infrastructure.OAuth2AuthenticationSuccessHandler;
+import com.swipelab.dto.request.InviteAdminRequest;
+import com.swipelab.users.application.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Security slice test for the admin invite endpoint.
+ *
+ * Uses @WebMvcTest so Spring Security's full method-security interceptor
+ * is active and @PreAuthorize is evaluated.
+ *
+ * Key design decisions:
+ * - SecurityAuthorizationService is a @MockBean so we control isSuperAdmin()
+ *   return values precisely. @Import loses the bean name qualifier needed
+ *   for the SpEL "@securityAuthorizationService" reference.
+ * - .with(csrf()) is required because @WebMvcTest re-enables CSRF by default
+ *   even though SecurityConfig disables it in production.
+ * - All SecurityConfig @Autowired filter dependencies are provided as @MockBean
+ *   (no-op stubs) so the application context loads cleanly.
+ *
+ * Covers:
+ *  - Edge: anonymous caller (unauthenticated) → 403
+ *  - Edge: authenticated USER where isSuperAdmin returns false → 403
+ *  - Edge: authenticated RESEARCHER where isSuperAdmin returns false → 403
+ *  - Happy: authenticated caller where isSuperAdmin returns true → 200, service invoked
+ */
+@WebMvcTest(AuthController.class)
+@Import({
+    com.swipelab.auth.infrastructure.SecurityConfig.class,
+    SecurityAuthorizationService.class
+})
+@TestPropertySource(properties = {
+        "app.security.super-admin.username=superadmin@swipelab.com",
+        "cors.allowed-origins=http://localhost:3000",
+        "app.frontend-url=http://localhost:3000"
+})
+@DisplayName("POST /api/v1/auth/invitation/admin — @PreAuthorize guard")
+class InviteAdminSecurityTest {
+
+    private static final String ENDPOINT = "/api/v1/auth/invitation/admin";
+
+    @Autowired private MockMvc      mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+
+    // ── AuthController collaborators ──────────────────────────────────────────
+    @MockBean private AuthenticationService              authenticationService;
+    @MockBean private UserService                        userService;
+    @MockBean private OAuth2Service                      oAuth2Service;
+    @MockBean private AuthMapper                         authMapper;
+    @MockBean private JwtService                         jwtService;
+
+    // ── SecurityConfig filter dependencies ────────────────────────────────────
+    @MockBean private JwtAuthenticationFilter            jwtAuthenticationFilter;
+    @MockBean private ExternalAuthFilter                 externalAuthFilter;
+    @MockBean private BannedUserFilter                   bannedUserFilter;
+    @MockBean private OAuth2AuthenticationSuccessHandler oAuth2SuccessHandler;
+    @MockBean private OAuth2AuthenticationFailureHandler oAuth2FailureHandler;
+    @MockBean private CustomOAuth2UserService            customOAuth2UserService;
+
+    // ── Setup ─────────────────────────────────────────────────────────────────
+
+    @org.junit.jupiter.api.BeforeEach
+    void setupFilterChains() throws Exception {
+        // Since the filters are mocked, their doFilter methods do nothing by default,
+        // which swallows the request and returns an empty 200 OK without reaching the controller.
+        // We must configure them to proceed down the chain.
+        org.mockito.stubbing.Answer<Void> proceed = invocation -> {
+            jakarta.servlet.FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        };
+
+        doAnswer(proceed).when(jwtAuthenticationFilter).doFilter(any(), any(), any());
+        doAnswer(proceed).when(externalAuthFilter).doFilter(any(), any(), any());
+        doAnswer(proceed).when(bannedUserFilter).doFilter(any(), any(), any());
+    }
+
+    // ── Helper ────────────────────────────────────────────────────────────────
+
+    private String validBody() throws Exception {
+        InviteAdminRequest req = new InviteAdminRequest();
+        req.setEmail("new.researcher@example.com");
+        return objectMapper.writeValueAsString(req);
+    }
+
+    // ── Edge cases ────────────────────────────────────────────────────────────
+
+    @Test
+    @WithAnonymousUser
+    @DisplayName("anonymous caller is rejected with 403")
+    void anonymousCaller_isRejected() throws Exception {
+        mockMvc.perform(post(ENDPOINT)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(validBody())
+                        .with(csrf()))
+                .andExpect(status().isForbidden());
+
+        verify(authenticationService, never()).inviteAdmin(any());
+    }
+
+    @Test
+    @WithMockUser(username = "regular_user", roles = "USER")
+    @DisplayName("USER role is rejected with 403")
+    void regularUser_isRejected() throws Exception {
+        mockMvc.perform(post(ENDPOINT)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(validBody())
+                        .with(csrf()))
+                .andExpect(status().isForbidden());
+
+        verify(authenticationService, never()).inviteAdmin(any());
+    }
+
+    @Test
+    @WithMockUser(username = "researcher_not_superadmin", roles = "RESEARCHER")
+    @DisplayName("RESEARCHER who is NOT super-admin is rejected with 403")
+    void researcher_nonSuperAdmin_isRejected() throws Exception {
+        mockMvc.perform(post(ENDPOINT)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(validBody())
+                        .with(csrf()))
+                .andExpect(status().isForbidden());
+
+        verify(authenticationService, never()).inviteAdmin(any());
+    }
+
+    // ── Happy flow ────────────────────────────────────────────────────────────
+
+    @Test
+    @WithMockUser(username = "superadmin@swipelab.com", roles = "RESEARCHER")
+    @DisplayName("super-admin is allowed and service is invoked exactly once")
+    void superAdmin_isAllowedAndServiceInvoked() throws Exception {
+        doNothing().when(authenticationService).inviteAdmin(any(InviteAdminRequest.class));
+
+        mockMvc.perform(post(ENDPOINT)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(validBody())
+                        .with(csrf()))
+                .andDo(org.springframework.test.web.servlet.result.MockMvcResultHandlers.print())
+                .andExpect(status().isOk());
+
+        verify(authenticationService, times(1)).inviteAdmin(any(InviteAdminRequest.class));
+    }
+}

--- a/backend/src/test/java/com/swipelab/auth/api/InviteAdminSecurityTest.java
+++ b/backend/src/test/java/com/swipelab/auth/api/InviteAdminSecurityTest.java
@@ -12,6 +12,7 @@ import com.swipelab.auth.infrastructure.CustomOAuth2UserService;
 import com.swipelab.auth.infrastructure.JwtAuthenticationFilter;
 import com.swipelab.auth.infrastructure.OAuth2AuthenticationFailureHandler;
 import com.swipelab.auth.infrastructure.OAuth2AuthenticationSuccessHandler;
+import com.swipelab.auth.infrastructure.RateLimitingFilter;
 import com.swipelab.dto.request.InviteAdminRequest;
 import com.swipelab.users.application.UserService;
 import org.junit.jupiter.api.DisplayName;
@@ -83,6 +84,7 @@ class InviteAdminSecurityTest {
     @MockBean private JwtAuthenticationFilter            jwtAuthenticationFilter;
     @MockBean private ExternalAuthFilter                 externalAuthFilter;
     @MockBean private BannedUserFilter                   bannedUserFilter;
+    @MockBean private RateLimitingFilter                 rateLimitingFilter;
     @MockBean private OAuth2AuthenticationSuccessHandler oAuth2SuccessHandler;
     @MockBean private OAuth2AuthenticationFailureHandler oAuth2FailureHandler;
     @MockBean private CustomOAuth2UserService            customOAuth2UserService;
@@ -103,6 +105,7 @@ class InviteAdminSecurityTest {
         doAnswer(proceed).when(jwtAuthenticationFilter).doFilter(any(), any(), any());
         doAnswer(proceed).when(externalAuthFilter).doFilter(any(), any(), any());
         doAnswer(proceed).when(bannedUserFilter).doFilter(any(), any(), any());
+        doAnswer(proceed).when(rateLimitingFilter).doFilter(any(), any(), any());
     }
 
     // ── Helper ────────────────────────────────────────────────────────────────

--- a/backend/src/test/java/com/swipelab/auth/infrastructure/RateLimitingFilterTest.java
+++ b/backend/src/test/java/com/swipelab/auth/infrastructure/RateLimitingFilterTest.java
@@ -1,0 +1,145 @@
+package com.swipelab.auth.infrastructure;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for RateLimitingFilter.
+ *
+ * Uses MockHttpServletRequest/Response so no Spring context is needed.
+ * Each test creates a fresh filter instance to guarantee an empty bucket cache.
+ *
+ * Covers:
+ *  - Happy flow: requests within limit are forwarded (200 chain continues)
+ *  - Edge case: request exceeding limit is rejected with 429
+ *  - Edge case: non-rate-limited URI is always forwarded
+ *  - Edge case: X-Forwarded-For header is used for key resolution
+ */
+@DisplayName("RateLimitingFilter")
+class RateLimitingFilterTest {
+
+    private RateLimitingFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        filter = new RateLimitingFilter();
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private MockHttpServletRequest request(String uri, String remoteAddr) {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", uri);
+        req.setRequestURI(uri);
+        req.setRemoteAddr(remoteAddr);
+        return req;
+    }
+
+    private int doFilter(MockHttpServletRequest req) throws Exception {
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+        filter.doFilterInternal(req, res, chain);
+        return res.getStatus();
+    }
+
+    // ── Happy flow ────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("first 5 login requests from same IP are allowed (within limit)")
+    void loginEndpoint_allowsFirst5RequestsFromSameIp() throws Exception {
+        MockHttpServletRequest req = request("/api/v1/auth/login", "10.0.0.1");
+
+        for (int i = 0; i < 5; i++) {
+            // MockFilterChain.getResponse() returns 200 by default
+            MockHttpServletResponse res = new MockHttpServletResponse();
+            MockFilterChain chain = new MockFilterChain();
+            filter.doFilterInternal(req, res, chain);
+            // Chain was called — response not written by filter, so status is 200
+            assertThat(chain.getRequest()).isNotNull();
+        }
+    }
+
+    // ── Edge cases ────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("6th login request from same IP is rejected with 429")
+    void loginEndpoint_rejects6thRequestWithTooManyRequests() throws Exception {
+        MockHttpServletRequest req = request("/api/v1/auth/login", "10.0.0.2");
+
+        // Exhaust the 5-per-minute bucket
+        for (int i = 0; i < 5; i++) {
+            MockHttpServletResponse res = new MockHttpServletResponse();
+            filter.doFilterInternal(req, res, new MockFilterChain());
+        }
+
+        // 6th attempt must be rate-limited
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+        filter.doFilterInternal(req, res, chain);
+
+        assertThat(res.getStatus()).isEqualTo(429);
+        assertThat(res.getContentAsString()).contains("Rate limit exceeded");
+        // Chain must NOT have been invoked
+        assertThat(chain.getRequest()).isNull();
+    }
+
+    @Test
+    @DisplayName("non-rate-limited URI is always forwarded regardless of call count")
+    void nonRateLimitedUri_isAlwaysForwarded() throws Exception {
+        MockHttpServletRequest req = request("/api/v1/images/42/content", "10.0.0.3");
+
+        for (int i = 0; i < 20; i++) {
+            MockHttpServletResponse res = new MockHttpServletResponse();
+            MockFilterChain chain = new MockFilterChain();
+            filter.doFilterInternal(req, res, chain);
+            assertThat(chain.getRequest()).isNotNull(); // chain was called every time
+        }
+    }
+
+    @Test
+    @DisplayName("different IPs have independent buckets on the same endpoint")
+    void differentIps_haveIndependentBuckets() throws Exception {
+        // Exhaust IP-A's bucket
+        MockHttpServletRequest reqA = request("/api/v1/auth/login", "10.0.0.4");
+        for (int i = 0; i < 5; i++) {
+            filter.doFilterInternal(reqA, new MockHttpServletResponse(), new MockFilterChain());
+        }
+
+        // IP-B should still be allowed (fresh bucket)
+        MockHttpServletRequest reqB = request("/api/v1/auth/login", "10.0.0.5");
+        MockHttpServletResponse resB = new MockHttpServletResponse();
+        MockFilterChain chainB = new MockFilterChain();
+        filter.doFilterInternal(reqB, resB, chainB);
+
+        assertThat(chainB.getRequest()).isNotNull();   // forwarded
+        assertThat(resB.getStatus()).isNotEqualTo(429); // not blocked
+    }
+
+    @Test
+    @DisplayName("X-Forwarded-For header is used for IP resolution (proxy-aware)")
+    void xForwardedFor_isUsedForIpResolution() throws Exception {
+        MockHttpServletRequest req = request("/api/v1/auth/login", "127.0.0.1");
+        req.addHeader("X-Forwarded-For", "203.0.113.5, 10.0.0.1");
+
+        // Should use 203.0.113.5 as the key, not 127.0.0.1.
+        // Exhaust the forwarded IP's bucket.
+        for (int i = 0; i < 5; i++) {
+            filter.doFilterInternal(req, new MockHttpServletResponse(), new MockFilterChain());
+        }
+
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+        filter.doFilterInternal(req, res, chain);
+
+        assertThat(res.getStatus()).isEqualTo(429);
+        assertThat(chain.getRequest()).isNull();
+    }
+}

--- a/backend/src/test/java/com/swipelab/auth/infrastructure/RateLimitingFilterTest.java
+++ b/backend/src/test/java/com/swipelab/auth/infrastructure/RateLimitingFilterTest.java
@@ -53,11 +53,11 @@ class RateLimitingFilterTest {
     // ── Happy flow ────────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("first 5 login requests from same IP are allowed (within limit)")
-    void loginEndpoint_allowsFirst5RequestsFromSameIp() throws Exception {
+    @DisplayName("first 20 login requests from same IP are allowed (within limit)")
+    void loginEndpoint_allowsFirst20RequestsFromSameIp() throws Exception {
         MockHttpServletRequest req = request("/api/v1/auth/login", "10.0.0.1");
 
-        for (int i = 0; i < 5; i++) {
+        for (int i = 0; i < 20; i++) {
             // MockFilterChain.getResponse() returns 200 by default
             MockHttpServletResponse res = new MockHttpServletResponse();
             MockFilterChain chain = new MockFilterChain();
@@ -70,17 +70,17 @@ class RateLimitingFilterTest {
     // ── Edge cases ────────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("6th login request from same IP is rejected with 429")
-    void loginEndpoint_rejects6thRequestWithTooManyRequests() throws Exception {
+    @DisplayName("21st login request from same IP is rejected with 429")
+    void loginEndpoint_rejects21stRequestWithTooManyRequests() throws Exception {
         MockHttpServletRequest req = request("/api/v1/auth/login", "10.0.0.2");
 
-        // Exhaust the 5-per-minute bucket
-        for (int i = 0; i < 5; i++) {
+        // Exhaust the 20-per-minute bucket
+        for (int i = 0; i < 20; i++) {
             MockHttpServletResponse res = new MockHttpServletResponse();
             filter.doFilterInternal(req, res, new MockFilterChain());
         }
 
-        // 6th attempt must be rate-limited
+        // 21st attempt must be rate-limited
         MockHttpServletResponse res = new MockHttpServletResponse();
         MockFilterChain chain = new MockFilterChain();
         filter.doFilterInternal(req, res, chain);
@@ -96,7 +96,7 @@ class RateLimitingFilterTest {
     void nonRateLimitedUri_isAlwaysForwarded() throws Exception {
         MockHttpServletRequest req = request("/api/v1/images/42/content", "10.0.0.3");
 
-        for (int i = 0; i < 20; i++) {
+        for (int i = 0; i < 30; i++) {
             MockHttpServletResponse res = new MockHttpServletResponse();
             MockFilterChain chain = new MockFilterChain();
             filter.doFilterInternal(req, res, chain);
@@ -109,7 +109,7 @@ class RateLimitingFilterTest {
     void differentIps_haveIndependentBuckets() throws Exception {
         // Exhaust IP-A's bucket
         MockHttpServletRequest reqA = request("/api/v1/auth/login", "10.0.0.4");
-        for (int i = 0; i < 5; i++) {
+        for (int i = 0; i < 20; i++) {
             filter.doFilterInternal(reqA, new MockHttpServletResponse(), new MockFilterChain());
         }
 
@@ -131,7 +131,7 @@ class RateLimitingFilterTest {
 
         // Should use 203.0.113.5 as the key, not 127.0.0.1.
         // Exhaust the forwarded IP's bucket.
-        for (int i = 0; i < 5; i++) {
+        for (int i = 0; i < 20; i++) {
             filter.doFilterInternal(req, new MockHttpServletResponse(), new MockFilterChain());
         }
 

--- a/backend/src/test/java/com/swipelab/config/MaliciousLabelingConfigServiceTest.java
+++ b/backend/src/test/java/com/swipelab/config/MaliciousLabelingConfigServiceTest.java
@@ -1,7 +1,8 @@
-package com.swipelab.config.application;
+package com.swipelab.config;
 
 import com.swipelab.config.application.dto.MaliciousLabelingConfigResponse;
 import com.swipelab.config.application.dto.UpdateMaliciousLabelingConfigRequest;
+import com.swipelab.config.application.MaliciousLabelingConfigService;
 import com.swipelab.config.domain.ConfigAuditLog;
 import com.swipelab.config.domain.SystemConfiguration;
 import com.swipelab.config.infrastructure.ConfigAuditLogRepository;
@@ -33,206 +34,207 @@ import static org.mockito.Mockito.*;
 @DisplayName("MaliciousLabelingConfigService")
 class MaliciousLabelingConfigServiceTest {
 
-    @Mock private SystemConfigurationRepository configRepository;
-    @Mock private ConfigAuditLogRepository auditRepository;
+        @Mock
+        private SystemConfigurationRepository configRepository;
+        @Mock
+        private ConfigAuditLogRepository auditRepository;
 
-    @InjectMocks
-    private MaliciousLabelingConfigService configService;
+        @InjectMocks
+        private MaliciousLabelingConfigService configService;
 
-    // ── Helpers ───────────────────────────────────────────────────────────────
+        // ── Helpers ───────────────────────────────────────────────────────────────
 
-    private SystemConfiguration entry(String key, String value) {
-        return SystemConfiguration.builder()
-                .id(1L)
-                .configKey(key)
-                .configValue(value)
-                .updatedAt(LocalDateTime.now())
-                .build();
-    }
+        private SystemConfiguration entry(String key, String value) {
+                return SystemConfiguration.builder()
+                                .id(1L)
+                                .configKey(key)
+                                .configValue(value)
+                                .updatedAt(LocalDateTime.now())
+                                .build();
+        }
 
-    private void stubAllKeys() {
-        lenient().when(configRepository.findByConfigKey("credibility.malicious_threshold"))
-                .thenReturn(Optional.of(entry("credibility.malicious_threshold", "15.0")));
-        lenient().when(configRepository.findByConfigKey("credibility.malicious_min_samples"))
-                .thenReturn(Optional.of(entry("credibility.malicious_min_samples", "20")));
-        lenient().when(configRepository.findByConfigKey("fraud.auto_ban_enabled"))
-                .thenReturn(Optional.of(entry("fraud.auto_ban_enabled", "true")));
-        lenient().when(configRepository.findByConfigKey("fraud.min_response_time_ms"))
-                .thenReturn(Optional.of(entry("fraud.min_response_time_ms", "300")));
-        lenient().when(configRepository.findByConfigKey("fraud.researcher_min_response_time_ms"))
-                .thenReturn(Optional.of(entry("fraud.researcher_min_response_time_ms", "150")));
-        lenient().when(configRepository.findByConfigKey("fraud.suspicious_count_for_strike"))
-                .thenReturn(Optional.of(entry("fraud.suspicious_count_for_strike", "3")));
-        lenient().when(configRepository.findByConfigKey("fraud.sliding_window_minutes"))
-                .thenReturn(Optional.of(entry("fraud.sliding_window_minutes", "10")));
-        lenient().when(configRepository.findByConfigKey("fraud.strikes_for_warning_1"))
-                .thenReturn(Optional.of(entry("fraud.strikes_for_warning_1", "5")));
-        lenient().when(configRepository.findByConfigKey("fraud.strikes_for_warning_2"))
-                .thenReturn(Optional.of(entry("fraud.strikes_for_warning_2", "10")));
-        lenient().when(configRepository.findByConfigKey("fraud.strikes_for_ban"))
-                .thenReturn(Optional.of(entry("fraud.strikes_for_ban", "15")));
-        lenient().when(configRepository.findByConfigKey("fraud.warning_cooldown_minutes"))
-                .thenReturn(Optional.of(entry("fraud.warning_cooldown_minutes", "30")));
-    }
+        private void stubAllKeys() {
+                lenient().when(configRepository.findByConfigKey("credibility.malicious_threshold"))
+                                .thenReturn(Optional.of(entry("credibility.malicious_threshold", "15.0")));
+                lenient().when(configRepository.findByConfigKey("credibility.malicious_min_samples"))
+                                .thenReturn(Optional.of(entry("credibility.malicious_min_samples", "20")));
+                lenient().when(configRepository.findByConfigKey("fraud.auto_ban_enabled"))
+                                .thenReturn(Optional.of(entry("fraud.auto_ban_enabled", "true")));
+                lenient().when(configRepository.findByConfigKey("fraud.min_response_time_ms"))
+                                .thenReturn(Optional.of(entry("fraud.min_response_time_ms", "300")));
+                lenient().when(configRepository.findByConfigKey("fraud.researcher_min_response_time_ms"))
+                                .thenReturn(Optional.of(entry("fraud.researcher_min_response_time_ms", "150")));
+                lenient().when(configRepository.findByConfigKey("fraud.suspicious_count_for_strike"))
+                                .thenReturn(Optional.of(entry("fraud.suspicious_count_for_strike", "3")));
+                lenient().when(configRepository.findByConfigKey("fraud.sliding_window_minutes"))
+                                .thenReturn(Optional.of(entry("fraud.sliding_window_minutes", "10")));
+                lenient().when(configRepository.findByConfigKey("fraud.strikes_for_warning_1"))
+                                .thenReturn(Optional.of(entry("fraud.strikes_for_warning_1", "5")));
+                lenient().when(configRepository.findByConfigKey("fraud.strikes_for_warning_2"))
+                                .thenReturn(Optional.of(entry("fraud.strikes_for_warning_2", "10")));
+                lenient().when(configRepository.findByConfigKey("fraud.strikes_for_ban"))
+                                .thenReturn(Optional.of(entry("fraud.strikes_for_ban", "15")));
+                lenient().when(configRepository.findByConfigKey("fraud.warning_cooldown_minutes"))
+                                .thenReturn(Optional.of(entry("fraud.warning_cooldown_minutes", "30")));
+        }
 
-    // ── Happy flows ───────────────────────────────────────────────────────────
+        // ── Happy flows ───────────────────────────────────────────────────────────
 
-    @Test
-    @DisplayName("getMaliciousLabelingConfig: returns correct values from DB")
-    void getConfig_returnsAllValuesFromDb() {
-        stubAllKeys();
+        @Test
+        @DisplayName("getMaliciousLabelingConfig: returns correct values from DB")
+        void getConfig_returnsAllValuesFromDb() {
+                stubAllKeys();
 
-        MaliciousLabelingConfigResponse cfg = configService.getMaliciousLabelingConfig();
+                MaliciousLabelingConfigResponse cfg = configService.getMaliciousLabelingConfig();
 
-        assertThat(cfg.getMaliciousThreshold()).isEqualTo(15.0);
-        assertThat(cfg.getMaliciousMinSamples()).isEqualTo(20);
-        assertThat(cfg.isAutoBanEnabled()).isTrue();
-        assertThat(cfg.getMinResponseTimeMs()).isEqualTo(300L);
-        assertThat(cfg.getResearcherMinResponseTimeMs()).isEqualTo(150L);
-        assertThat(cfg.getSuspiciousCountForStrike()).isEqualTo(3);
-        assertThat(cfg.getSlidingWindowMinutes()).isEqualTo(10);
-        assertThat(cfg.getStrikesForWarning1()).isEqualTo(5);
-        assertThat(cfg.getStrikesForWarning2()).isEqualTo(10);
-        assertThat(cfg.getStrikesForBan()).isEqualTo(15);
-        assertThat(cfg.getWarningCooldownMinutes()).isEqualTo(30);
-    }
+                assertThat(cfg.getMaliciousThreshold()).isEqualTo(15.0);
+                assertThat(cfg.getMaliciousMinSamples()).isEqualTo(20);
+                assertThat(cfg.isAutoBanEnabled()).isTrue();
+                assertThat(cfg.getMinResponseTimeMs()).isEqualTo(300L);
+                assertThat(cfg.getResearcherMinResponseTimeMs()).isEqualTo(150L);
+                assertThat(cfg.getSuspiciousCountForStrike()).isEqualTo(3);
+                assertThat(cfg.getSlidingWindowMinutes()).isEqualTo(10);
+                assertThat(cfg.getStrikesForWarning1()).isEqualTo(5);
+                assertThat(cfg.getStrikesForWarning2()).isEqualTo(10);
+                assertThat(cfg.getStrikesForBan()).isEqualTo(15);
+                assertThat(cfg.getWarningCooldownMinutes()).isEqualTo(30);
+        }
 
-    @Test
-    @DisplayName("updateConfig: single field — persists new value and appends audit record")
-    void updateConfig_singleField_persistsAndAudits() {
-        stubAllKeys();
+        @Test
+        @DisplayName("updateConfig: single field — persists new value and appends audit record")
+        void updateConfig_singleField_persistsAndAudits() {
+                stubAllKeys();
 
-        SystemConfiguration thresholdEntry = entry("credibility.malicious_threshold", "15.0");
-        when(configRepository.findByConfigKey("credibility.malicious_threshold"))
-                .thenReturn(Optional.of(thresholdEntry));
-        when(configRepository.save(any())).thenReturn(thresholdEntry);
-        when(auditRepository.save(any())).thenReturn(new ConfigAuditLog());
+                SystemConfiguration thresholdEntry = entry("credibility.malicious_threshold", "15.0");
+                when(configRepository.findByConfigKey("credibility.malicious_threshold"))
+                                .thenReturn(Optional.of(thresholdEntry));
+                when(configRepository.save(any())).thenReturn(thresholdEntry);
+                when(auditRepository.save(any())).thenReturn(new ConfigAuditLog());
 
-        UpdateMaliciousLabelingConfigRequest req = new UpdateMaliciousLabelingConfigRequest();
-        req.setMaliciousThreshold(20.0);
+                UpdateMaliciousLabelingConfigRequest req = new UpdateMaliciousLabelingConfigRequest();
+                req.setMaliciousThreshold(20.0);
 
-        configService.updateConfig(req, "superadmin");
+                configService.updateConfig(req, "superadmin");
 
-        ArgumentCaptor<SystemConfiguration> savedConfig = ArgumentCaptor.forClass(SystemConfiguration.class);
-        verify(configRepository, atLeastOnce()).save(savedConfig.capture());
-        assertThat(savedConfig.getValue().getConfigValue()).isEqualTo("20.0");
-        assertThat(savedConfig.getValue().getUpdatedBy()).isEqualTo("superadmin");
+                ArgumentCaptor<SystemConfiguration> savedConfig = ArgumentCaptor.forClass(SystemConfiguration.class);
+                verify(configRepository, atLeastOnce()).save(savedConfig.capture());
+                assertThat(savedConfig.getValue().getConfigValue()).isEqualTo("20.0");
+                assertThat(savedConfig.getValue().getUpdatedBy()).isEqualTo("superadmin");
 
-        ArgumentCaptor<ConfigAuditLog> auditCaptor = ArgumentCaptor.forClass(ConfigAuditLog.class);
-        verify(auditRepository, atLeastOnce()).save(auditCaptor.capture());
-        assertThat(auditCaptor.getValue().getConfigKey()).isEqualTo("credibility.malicious_threshold");
-        assertThat(auditCaptor.getValue().getPreviousValue()).isEqualTo("15.0");
-        assertThat(auditCaptor.getValue().getNewValue()).isEqualTo("20.0");
-        assertThat(auditCaptor.getValue().getChangedBy()).isEqualTo("superadmin");
-    }
+                ArgumentCaptor<ConfigAuditLog> auditCaptor = ArgumentCaptor.forClass(ConfigAuditLog.class);
+                verify(auditRepository, atLeastOnce()).save(auditCaptor.capture());
+                assertThat(auditCaptor.getValue().getConfigKey()).isEqualTo("credibility.malicious_threshold");
+                assertThat(auditCaptor.getValue().getPreviousValue()).isEqualTo("15.0");
+                assertThat(auditCaptor.getValue().getNewValue()).isEqualTo("20.0");
+                assertThat(auditCaptor.getValue().getChangedBy()).isEqualTo("superadmin");
+        }
 
-    @Test
-    @DisplayName("updateConfig: auto-ban toggled to false — persisted and audited")
-    void updateConfig_autoBanToggle_persistsAndAudits() {
-        stubAllKeys();
+        @Test
+        @DisplayName("updateConfig: auto-ban toggled to false — persisted and audited")
+        void updateConfig_autoBanToggle_persistsAndAudits() {
+                stubAllKeys();
 
-        SystemConfiguration banEntry = entry("fraud.auto_ban_enabled", "true");
-        when(configRepository.findByConfigKey("fraud.auto_ban_enabled"))
-                .thenReturn(Optional.of(banEntry));
-        when(configRepository.save(any())).thenReturn(banEntry);
-        when(auditRepository.save(any())).thenReturn(new ConfigAuditLog());
+                SystemConfiguration banEntry = entry("fraud.auto_ban_enabled", "true");
+                when(configRepository.findByConfigKey("fraud.auto_ban_enabled"))
+                                .thenReturn(Optional.of(banEntry));
+                when(configRepository.save(any())).thenReturn(banEntry);
+                when(auditRepository.save(any())).thenReturn(new ConfigAuditLog());
 
-        UpdateMaliciousLabelingConfigRequest req = new UpdateMaliciousLabelingConfigRequest();
-        req.setAutoBanEnabled(false);
+                UpdateMaliciousLabelingConfigRequest req = new UpdateMaliciousLabelingConfigRequest();
+                req.setAutoBanEnabled(false);
 
-        configService.updateConfig(req, "superadmin");
+                configService.updateConfig(req, "superadmin");
 
-        ArgumentCaptor<ConfigAuditLog> auditCaptor = ArgumentCaptor.forClass(ConfigAuditLog.class);
-        verify(auditRepository, atLeastOnce()).save(auditCaptor.capture());
-        assertThat(auditCaptor.getValue().getConfigKey()).isEqualTo("fraud.auto_ban_enabled");
-        assertThat(auditCaptor.getValue().getNewValue()).isEqualTo("false");
-    }
+                ArgumentCaptor<ConfigAuditLog> auditCaptor = ArgumentCaptor.forClass(ConfigAuditLog.class);
+                verify(auditRepository, atLeastOnce()).save(auditCaptor.capture());
+                assertThat(auditCaptor.getValue().getConfigKey()).isEqualTo("fraud.auto_ban_enabled");
+                assertThat(auditCaptor.getValue().getNewValue()).isEqualTo("false");
+        }
 
-    @Test
-    @DisplayName("getAuditLog: returns paginated audit entries newest-first")
-    void getAuditLog_returnsPaginatedEntries() {
-        ConfigAuditLog log = ConfigAuditLog.builder()
-                .id(1L).configKey("fraud.auto_ban_enabled")
-                .previousValue("true").newValue("false")
-                .changedBy("admin").changedAt(LocalDateTime.now()).build();
+        @Test
+        @DisplayName("getAuditLog: returns paginated audit entries newest-first")
+        void getAuditLog_returnsPaginatedEntries() {
+                ConfigAuditLog log = ConfigAuditLog.builder()
+                                .id(1L).configKey("fraud.auto_ban_enabled")
+                                .previousValue("true").newValue("false")
+                                .changedBy("admin").changedAt(LocalDateTime.now()).build();
 
-        Page<ConfigAuditLog> page = new PageImpl<>(List.of(log));
-        when(auditRepository.findAllByOrderByChangedAtDesc(any())).thenReturn(page);
+                Page<ConfigAuditLog> page = new PageImpl<>(List.of(log));
+                when(auditRepository.findAllByOrderByChangedAtDesc(any())).thenReturn(page);
 
-        Page<com.swipelab.config.application.dto.ConfigAuditLogResponse> result =
-                configService.getAuditLog(PageRequest.of(0, 20));
+                Page<com.swipelab.config.application.dto.ConfigAuditLogResponse> result = configService
+                                .getAuditLog(PageRequest.of(0, 20));
 
-        assertThat(result.getContent()).hasSize(1);
-        assertThat(result.getContent().get(0).getConfigKey()).isEqualTo("fraud.auto_ban_enabled");
-        assertThat(result.getContent().get(0).getPreviousValue()).isEqualTo("true");
-        assertThat(result.getContent().get(0).getNewValue()).isEqualTo("false");
-        assertThat(result.getContent().get(0).getChangedBy()).isEqualTo("admin");
-    }
+                assertThat(result.getContent()).hasSize(1);
+                assertThat(result.getContent().get(0).getConfigKey()).isEqualTo("fraud.auto_ban_enabled");
+                assertThat(result.getContent().get(0).getPreviousValue()).isEqualTo("true");
+                assertThat(result.getContent().get(0).getNewValue()).isEqualTo("false");
+                assertThat(result.getContent().get(0).getChangedBy()).isEqualTo("admin");
+        }
 
-    // ── Validation edge cases ─────────────────────────────────────────────────
+        // ── Validation edge cases ─────────────────────────────────────────────────
 
-    @Test
-    @DisplayName("updateConfig: maliciousThreshold > 100 → IllegalArgumentException, nothing saved")
-    void updateConfig_thresholdOutOfRange_throws() {
-        stubAllKeys();
+        @Test
+        @DisplayName("updateConfig: maliciousThreshold > 100 → IllegalArgumentException, nothing saved")
+        void updateConfig_thresholdOutOfRange_throws() {
+                stubAllKeys();
 
-        UpdateMaliciousLabelingConfigRequest req = new UpdateMaliciousLabelingConfigRequest();
-        req.setMaliciousThreshold(101.0);
+                UpdateMaliciousLabelingConfigRequest req = new UpdateMaliciousLabelingConfigRequest();
+                req.setMaliciousThreshold(101.0);
 
-        assertThatThrownBy(() -> configService.updateConfig(req, "superadmin"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("maliciousThreshold");
+                assertThatThrownBy(() -> configService.updateConfig(req, "superadmin"))
+                                .isInstanceOf(IllegalArgumentException.class)
+                                .hasMessageContaining("maliciousThreshold");
 
-        verify(configRepository, never()).save(any());
-        verify(auditRepository, never()).save(any());
-    }
+                verify(configRepository, never()).save(any());
+                verify(auditRepository, never()).save(any());
+        }
 
-    @Test
-    @DisplayName("updateConfig: researcherMinResponseTime > minResponseTime → rejected")
-    void updateConfig_researcherTimeExceedsRegular_throws() {
-        stubAllKeys();
+        @Test
+        @DisplayName("updateConfig: researcherMinResponseTime > minResponseTime → rejected")
+        void updateConfig_researcherTimeExceedsRegular_throws() {
+                stubAllKeys();
 
-        UpdateMaliciousLabelingConfigRequest req = new UpdateMaliciousLabelingConfigRequest();
-        req.setMinResponseTimeMs(200L);
-        req.setResearcherMinResponseTimeMs(500L); // exceeds regular threshold
+                UpdateMaliciousLabelingConfigRequest req = new UpdateMaliciousLabelingConfigRequest();
+                req.setMinResponseTimeMs(200L);
+                req.setResearcherMinResponseTimeMs(500L); // exceeds regular threshold
 
-        assertThatThrownBy(() -> configService.updateConfig(req, "superadmin"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("researcherMinResponseTimeMs");
+                assertThatThrownBy(() -> configService.updateConfig(req, "superadmin"))
+                                .isInstanceOf(IllegalArgumentException.class)
+                                .hasMessageContaining("researcherMinResponseTimeMs");
 
-        verify(configRepository, never()).save(any());
-    }
+                verify(configRepository, never()).save(any());
+        }
 
-    @Test
-    @DisplayName("updateConfig: strikesForWarning2 ≤ strikesForWarning1 → rejected")
-    void updateConfig_warning2SmallerThanWarning1_throws() {
-        stubAllKeys();
+        @Test
+        @DisplayName("updateConfig: strikesForWarning2 ≤ strikesForWarning1 → rejected")
+        void updateConfig_warning2SmallerThanWarning1_throws() {
+                stubAllKeys();
 
-        UpdateMaliciousLabelingConfigRequest req = new UpdateMaliciousLabelingConfigRequest();
-        req.setStrikesForWarning1(10);
-        req.setStrikesForWarning2(5); // must be > warning1
+                UpdateMaliciousLabelingConfigRequest req = new UpdateMaliciousLabelingConfigRequest();
+                req.setStrikesForWarning1(10);
+                req.setStrikesForWarning2(5); // must be > warning1
 
-        assertThatThrownBy(() -> configService.updateConfig(req, "superadmin"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("strikesForWarning2");
+                assertThatThrownBy(() -> configService.updateConfig(req, "superadmin"))
+                                .isInstanceOf(IllegalArgumentException.class)
+                                .hasMessageContaining("strikesForWarning2");
 
-        verify(configRepository, never()).save(any());
-    }
+                verify(configRepository, never()).save(any());
+        }
 
-    @Test
-    @DisplayName("updateConfig: strikesForBan ≤ strikesForWarning2 → rejected")
-    void updateConfig_banSmallerThanWarning2_throws() {
-        stubAllKeys();
+        @Test
+        @DisplayName("updateConfig: strikesForBan ≤ strikesForWarning2 → rejected")
+        void updateConfig_banSmallerThanWarning2_throws() {
+                stubAllKeys();
 
-        UpdateMaliciousLabelingConfigRequest req = new UpdateMaliciousLabelingConfigRequest();
-        req.setStrikesForBan(8); // current warning2 = 10 → ban must be > 10
+                UpdateMaliciousLabelingConfigRequest req = new UpdateMaliciousLabelingConfigRequest();
+                req.setStrikesForBan(8); // current warning2 = 10 → ban must be > 10
 
-        assertThatThrownBy(() -> configService.updateConfig(req, "superadmin"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("strikesForBan");
+                assertThatThrownBy(() -> configService.updateConfig(req, "superadmin"))
+                                .isInstanceOf(IllegalArgumentException.class)
+                                .hasMessageContaining("strikesForBan");
 
-        verify(configRepository, never()).save(any());
-    }
-
+                verify(configRepository, never()).save(any());
+        }
 
 }

--- a/backend/src/test/java/com/swipelab/users/application/UserServiceBanTest.java
+++ b/backend/src/test/java/com/swipelab/users/application/UserServiceBanTest.java
@@ -75,6 +75,11 @@ class UserServiceBanTest {
         SecurityContextHolder.setContext(ctx);
     }
 
+    @org.junit.jupiter.api.AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
     // ── Happy flow ────────────────────────────────────────────────────────────
 
     @Test

--- a/frontend/app/api/apiFetch.ts
+++ b/frontend/app/api/apiFetch.ts
@@ -126,7 +126,6 @@ export async function apiFetch(
 
   const fullUrl = backendUrl + input;
   console.log("[apiFetch] Full exact URL being fetch'ed:", fullUrl);
-  console.log("[apiFetch] Header Token Present:", token ? "YES (length " + token.length + ")" : "NO (null/undefined)");
 
   const response = await fetch(fullUrl, {
     ...init,


### PR DESCRIPTION
# Security Audit Remediation (#204)

## Overview
This pull request addresses and resolves multiple **Critical, High, and Medium** severity security findings identified during the recent security audit. The focus of these changes is hardening the authentication layer, securing internal endpoints, preventing enumeration and brute-force attacks, and eliminating injection vulnerabilities.

---

## 🔒 Security Breaches Fixed

### Critical Severity 🔴

#### 1. CRIT-03: Hardcoded Role Access to Admin APIs
* **The Breach:** Administrative endpoints were exposed without proper role validation, potentially allowing standard users or researchers to access admin functionalities if they bypassed frontend routing.
* **The Fix:** Secured all `/api/v1/admin/**` endpoints directly at the controller level using Spring Security's `@PreAuthorize("hasRole('ADMIN')")`. Verified authorization enforcement via `InviteAdminSecurityTest`.

### High Severity 🟠

#### 2. HIGH-02: Stored Cross-Site Scripting (XSS) via Thymeleaf Templates
* **The Breach:** The email verification templates (`email-verify-success.html` and `email-verify-failure.html`) were using `th:utext` (Unescaped Text). This allowed unescaped dynamic content to be rendered, opening a vector for Stored XSS if a user registered with a malicious payload in their email or name.
* **The Fix:** Refactored the templates to use `th:text`, which automatically escapes HTML entities, neutralizing any malicious script payloads.

#### 3. HIGH-03: Authentication Rate Limiting Missing
* **The Breach:** The authentication endpoints (`/login`, `/register`, etc.) had no rate limiting. This allowed attackers to perform unlimited brute-force credential stuffing and email bombing attacks.
* **The Fix:** Implemented a robust `RateLimitingFilter` using `Bucket4j` and a `Caffeine` in-memory cache. It tracks request counts by IP (respecting `X-Forwarded-For` for proxies) and blocks abusive clients with a `429 Too Many Requests` status. Limits are configured generously to avoid blocking legitimate testing (e.g., 20 logins/min) while still stopping automated bots.

#### 4. HIGH-04: Broad `permitAll` Configuration
* **The Breach:** The `SecurityConfig` previously used broad `permitAll()` rules that unintentionally exposed several sensitive endpoints, including the Gamification `SyncController`.
* **The Fix:** Refactored the security chain to use a strict **deny-by-default** allowlist. Furthermore, the `SyncController` was fully secured using a dedicated `ApiKeyAuthFilter` to enforce service-to-service API key validation.

### Medium Severity 🟡

#### 5. MED-01: Swagger UI Exposed in Production
* **The Breach:** API documentation (Swagger/OpenAPI) was accessible in the production environment, providing attackers with a complete blueprint of the API surface.
* **The Fix:** Bound the Swagger configuration conditionally so that the `/swagger-ui/**` and `/v3/api-docs` routes are strictly inaccessible when the active Spring profile is `prod`.

#### 6. MED-02: Verbose Global Exception Handler
* **The Breach:** Unhandled server exceptions were leaking internal stack traces and environment details directly to the client response, aiding reconnaissance.
* **The Fix:** Sanitized the `GlobalExceptionHandler`. It now logs the full stack trace server-side (using `@Slf4j`) for debugging purposes, but only returns safe, generic `"Internal Server Error"` messages to the client.

#### 7. MED-03: JWT Logs Leaking Plaintext Tokens
* **The Breach:** The `JwtAuthenticationFilter` was logging invalid JWT tokens in plaintext at the `WARN` level. This meant sensitive access tokens were being written to disk in server logs.
* **The Fix:** Downgraded the log level to `DEBUG` and scrubbed the actual token payload from the output messages entirely.

#### 8. MED-05: User Enumeration via Login
* **The Breach:** The login endpoint threw different error messages (`"User not exists"` vs `"Wrong password"`). An attacker could exploit this to enumerate and harvest valid usernames.
* **The Fix:** Unified the login error handling. Regardless of whether the username is wrong or the password is wrong, the backend now returns a generic `401 Unauthorized` with the message `"Invalid username or password"`.

---

## 🛠️ Additional Fixes
- **Configuration Compilation Fix:** Corrected a package mismatch and missing import in `MaliciousLabelingConfigServiceTest.java` that was breaking the CI build.
- **Test Coverage:** Added and updated unit tests (e.g., `RateLimitingFilterTest`, `InviteAdminSecurityTest`) to ensure the new security mechanisms enforce boundaries correctly without false positives.

## 🧪 Verification
- [x] All backend unit and integration tests pass successfully (`mvn clean test`).
- [x] Docker compose builds cleanly locally (`docker compose up --build`).
- [x] Tested rate limiter locally (verified `429` response upon hitting thresholds).
- [x] Verified user enumeration is no longer possible.
