### PR TITLE
fix(backend): calculate real task progress instead of hardcoded values

### DIFF
--- a/backend/src/main/java/com/swipelab/analytics/application/AnalyticsService.java
+++ b/backend/src/main/java/com/swipelab/analytics/application/AnalyticsService.java
@@ -198,11 +198,16 @@ public class AnalyticsService {
         List<ClassificationFact> facts = classificationFactRepository.findByTaskId(taskId);
         int totalClassifications = facts.size();
 
+        int totalImages = (int) imageRepository.countByTaskId(taskId);
+        double percentComplete = totalImages > 0
+                ? (double) completedImages / totalImages * 100
+                : 0.0;
+
         TaskAnalyticsResponse.Progress progress = TaskAnalyticsResponse.Progress.builder()
                 .imagesClassified(completedImages.intValue())
-                .totalImages(1000)
+                .totalImages(totalImages)
                 .completedImages(completedImages.intValue())
-                .percentComplete(0.0)
+                .percentComplete(percentComplete)
                 .build();
 
         List<TaskSpeciesStats> speciesStats = taskSpeciesStatsRepository.findByTaskId(taskId);

--- a/backend/src/main/java/com/swipelab/tasks/domain/TaskMapper.java
+++ b/backend/src/main/java/com/swipelab/tasks/domain/TaskMapper.java
@@ -121,7 +121,7 @@ public class TaskMapper {
                 .sharedWithResearchers(task.getSharedWithResearchers())
                 .isPublic(task.getIsPublic())
                 .targetSpecies(targetSpeciesProvider.getSpeciesByIdsAndRefImages(task.getTargetSpeciesIds(), task.getSpeciesReferenceImageIds()))
-                .progress(TaskProgressResponse.empty())
+                .progress(progress != null ? progress : TaskProgressResponse.empty())
                 // New fields
                 .createdAt(task.getCreatedAt() != null
                         ? java.time.OffsetDateTime.of(task.getCreatedAt(), java.time.ZoneOffset.UTC)

--- a/backend/src/test/java/com/swipelab/analytics/application/AnalyticsServiceTest.java
+++ b/backend/src/test/java/com/swipelab/analytics/application/AnalyticsServiceTest.java
@@ -2,6 +2,7 @@ package com.swipelab.analytics.application;
 
 import com.swipelab.analytics.domain.UserDailyStats;
 import com.swipelab.analytics.dto.PlatformOverviewResponse;
+import com.swipelab.analytics.dto.TaskAnalyticsResponse;
 import com.swipelab.analytics.dto.UserProgressResponse;
 import com.swipelab.analytics.infrastructure.*;
 import com.swipelab.classification.domain.Classification.UserResponse;
@@ -226,5 +227,40 @@ class AnalyticsServiceTest {
         assertEquals(1000L, stats.getTotalSwipes());
         assertEquals(5L, stats.getActiveTasks());
         assertEquals(300L, stats.getTotalImages());
+    }
+
+    // ─── getTaskAnalytics ─────────────────────────────────────────────────────
+
+    @Test
+    void getTaskAnalytics_happyFlow_computesProgressFromImageCounts() {
+        // 200 total crops in the task, 50 of them classified → 25 % complete
+        when(classificationFactRepository.countCompletedImages(1L)).thenReturn(50L);
+        when(classificationFactRepository.findByTaskId(1L)).thenReturn(Collections.emptyList());
+        when(taskSpeciesStatsRepository.findByTaskId(1L)).thenReturn(Collections.emptyList());
+        when(imageRepository.countByTaskId(1L)).thenReturn(200L);
+
+        TaskAnalyticsResponse response = analyticsService.getTaskAnalytics(1L);
+
+        TaskAnalyticsResponse.Progress progress = response.getProgress();
+        assertEquals(200, progress.getTotalImages());
+        assertEquals(50, progress.getImagesClassified());
+        assertEquals(50, progress.getCompletedImages());
+        assertEquals(25.0, progress.getPercentComplete(), 0.001);
+    }
+
+    @Test
+    void getTaskAnalytics_edgeCase_noImages_returnsZeroPercent() {
+        // No crops imported yet → avoid division by zero, report 0 %
+        when(classificationFactRepository.countCompletedImages(2L)).thenReturn(0L);
+        when(classificationFactRepository.findByTaskId(2L)).thenReturn(Collections.emptyList());
+        when(taskSpeciesStatsRepository.findByTaskId(2L)).thenReturn(Collections.emptyList());
+        when(imageRepository.countByTaskId(2L)).thenReturn(0L);
+
+        TaskAnalyticsResponse response = analyticsService.getTaskAnalytics(2L);
+
+        TaskAnalyticsResponse.Progress progress = response.getProgress();
+        assertEquals(0, progress.getTotalImages());
+        assertEquals(0, progress.getImagesClassified());
+        assertEquals(0.0, progress.getPercentComplete(), 0.001);
     }
 }

--- a/backend/src/test/java/com/swipelab/tasks/domain/TaskMapperTest.java
+++ b/backend/src/test/java/com/swipelab/tasks/domain/TaskMapperTest.java
@@ -4,6 +4,7 @@ import com.swipelab.tasks.application.port.out.TargetSpeciesProvider;
 import com.swipelab.dto.request.CreateTaskRequest;
 import com.swipelab.dto.request.UpdateTaskRequest;
 import com.swipelab.dto.response.TaskResponse;
+import com.swipelab.dto.response.TaskProgressResponse;
 import com.swipelab.dto.response.TargetSpeciesResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -80,6 +81,37 @@ class TaskMapperTest {
         assertEquals(1, response.getTargetSpecies().size());
         assertEquals("Dog", response.getTargetSpecies().get(0).getName());
         assertFalse(response.isAssignedToUser());
+    }
+
+    @Test
+    void toResponse_ShouldUseProvidedProgress_NotEmpty() {
+        // Regression guard: the 3-arg overload must surface the computed progress it is
+        // handed, not hardcode an empty (0/0) one. The researcher TaskCard / TaskDetails
+        // screens read this endpoint, so dropping the progress shows "0 of 0" forever.
+        Task task = new Task();
+        task.setId(7L);
+        task.setStatus(TaskStatus.ACTIVE);
+
+        TaskProgressResponse progress = new TaskProgressResponse(9, 1);
+
+        TaskResponse response = taskMapper.toResponse(task, false, progress);
+
+        assertNotNull(response.getProgress());
+        assertEquals(9, response.getProgress().getTotalImages());
+        assertEquals(1, response.getProgress().getImagesClassified());
+    }
+
+    @Test
+    void toResponse_ShouldFallBackToEmptyProgress_WhenNull() {
+        Task task = new Task();
+        task.setId(8L);
+        task.setStatus(TaskStatus.ACTIVE);
+
+        TaskResponse response = taskMapper.toResponse(task, false, null);
+
+        assertNotNull(response.getProgress());
+        assertEquals(0, response.getProgress().getTotalImages());
+        assertEquals(0, response.getProgress().getImagesClassified());
     }
 
     @Test


### PR DESCRIPTION
Fixes the "[Frontend] progress is not calculated" bug, where the researcher
TaskCard and TaskDetailsScreen always showed "0 of 0" at 0%. Despite the
[Frontend] label, the root cause was on the backend in two places:

- AnalyticsService.getTaskAnalytics() hardcoded totalImages = 1000 and
  percentComplete = 0.0 — now derived from imageRepository.countByTaskId().
- TaskMapper.toResponse(...) ignored its computed progress argument and
  hardcoded empty(), so GET /tasks/dashboard/{id} (the endpoint the screens
  actually read) always returned 0/0 — now it surfaces the real progress.

Added AnalyticsServiceTest + TaskMapperTest cases. Full backend suite: 432 passing.