### PR TITLE
[Frontend] Add reference image upload & selection pool to EditTaskScreen

### DIFF
--- a/frontend/app/components/researcher/addTask/SpeciesImagePicker.tsx
+++ b/frontend/app/components/researcher/addTask/SpeciesImagePicker.tsx
@@ -13,8 +13,11 @@ import {
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import * as ImagePicker from 'expo-image-picker';
+import { useQueryClient } from '@tanstack/react-query';
 import { Colors } from '../../../../constants/theme';
 import { useThemeStore } from '../../../stores/themeStore';
+import { API_ENDPOINTS } from '../../../api/apiEndpoints';
+import { apiFetch } from '../../../api/apiFetch';
 import { SpeciesRefImage } from './addTaskTypes';
 import AuthenticatedImage from '../../ui/AuthenticatedImage';
 
@@ -48,8 +51,10 @@ export default function SpeciesImagePicker({
 }: SpeciesImagePickerProps) {
   const { theme } = useThemeStore();
   const c = Colors[theme as keyof typeof Colors];
+  const queryClient = useQueryClient();
   const [modalVisible, setModalVisible] = useState(false);
   const [previewUri, setPreviewUri]     = useState<string | null>(null);
+  const [uploading, setUploading]       = useState(false);
 
   const isAtMax  = selectedImages.length >= MAX_IMAGES;
   const isValid  = selectedImages.length >= MIN_IMAGES;
@@ -76,13 +81,94 @@ export default function SpeciesImagePicker({
     }
   };
 
-  // ── Upload new image from device ───────────────────────────────────────────
+  // ── Upload new image(s) from device ────────────────────────────────────────
+  // Images are uploaded to the species pool *immediately* (not deferred to task
+  // submit). This makes the new image instantly selectable from the pool — and
+  // we invalidate the cached pool query so the grid refreshes without a reload.
+
+  /**
+   * Uploads picked files to the species pool, adds the returned pool images as
+   * selected (fromPool) entries, and refreshes the pool cache.
+   */
+  const uploadToPool = async (
+    files: { file?: File; uri?: string; name?: string }[],
+  ) => {
+    if (files.length === 0) return;
+    const remaining = MAX_IMAGES - selectedImages.length;
+    const toUpload = files.slice(0, remaining);
+
+    setUploading(true);
+    try {
+      const fd = new FormData();
+      toUpload.forEach((f) => {
+        if (Platform.OS === 'web') {
+          if (f.file) fd.append('files', f.file);
+        } else {
+          fd.append('files', {
+            uri: f.uri,
+            name: f.name || 'ref.jpg',
+            type: 'image/jpeg',
+          } as any);
+        }
+      });
+
+      const res = await apiFetch(API_ENDPOINTS.SPECIES.REF_IMAGES(speciesId), {
+        method: 'POST',
+        body: fd,
+      });
+      if (!res.ok) throw new Error(`Upload failed (${res.status})`);
+
+      const saved: { id: number; thumbnailUrl: string; imageUrl: string; caption?: string }[] =
+        await res.json();
+
+      // Add the freshly-uploaded images as selected pool entries.
+      const newSelected: SpeciesRefImage[] = saved.map((s) => ({
+        poolId: s.id,
+        uri: s.thumbnailUrl,
+        fromPool: true,
+        caption: s.caption,
+      }));
+      onImagesChange(speciesId, [...selectedImages, ...newSelected]);
+
+      // Make the new image appear in the pool grid right away.
+      // 1) Optimistically merge it into every cached pool query that includes
+      //    this species, so it shows instantly without waiting for a network round-trip.
+      queryClient.setQueriesData<Record<string, PoolImage[]>>(
+        { queryKey: ['species', 'pool'] },
+        (old) => {
+          if (!old) return old;
+          const existing = old[speciesId] ?? [];
+          const merged = [
+            ...existing,
+            ...saved
+              .filter((s) => !existing.some((p) => p.id === s.id))
+              .map((s) => ({
+                id: s.id,
+                thumbnailUrl: s.thumbnailUrl,
+                imageUrl: s.imageUrl,
+                caption: s.caption,
+              })),
+          ];
+          return { ...old, [speciesId]: merged };
+        },
+      );
+      // 2) Force an immediate refetch (not lazy invalidation) so the cache is
+      //    reconciled with the server right away — fixes the stale-cache delay.
+      queryClient.refetchQueries({ queryKey: ['species', 'pool'] });
+    } catch (err) {
+      console.error('Reference image upload failed:', err);
+      Alert.alert('Upload failed', 'Could not upload the image. Please try again.');
+    } finally {
+      setUploading(false);
+    }
+  };
 
   const handleUpload = async () => {
     if (isAtMax) {
       Alert.alert('Limit reached', `Maximum ${MAX_IMAGES} reference images per species.`);
       return;
     }
+    if (uploading) return;
 
     if (Platform.OS === 'web') {
       // Web: invisible file input
@@ -93,16 +179,7 @@ export default function SpeciesImagePicker({
       input.onchange = (e: Event) => {
         const files = (e.target as HTMLInputElement).files;
         if (!files) return;
-        const remaining = MAX_IMAGES - selectedImages.length;
-        const toAdd = Array.from(files).slice(0, remaining);
-        const newImages: SpeciesRefImage[] = toAdd.map((file) => ({
-          uri: URL.createObjectURL(file),
-          fromPool: false,
-          caption: file.name,
-          // Store file reference for FormData upload on submit
-          _file: file,
-        } as any));
-        onImagesChange(speciesId, [...selectedImages, ...newImages]);
+        void uploadToPool(Array.from(files).map((file) => ({ file, name: file.name })));
       };
       input.click();
     } else {
@@ -118,12 +195,9 @@ export default function SpeciesImagePicker({
         quality: 1, // Backend does compression; send full quality
       });
       if (!result.canceled) {
-        const newImages: SpeciesRefImage[] = result.assets.map((asset) => ({
-          uri: asset.uri,
-          fromPool: false,
-          caption: asset.fileName ?? undefined,
-        }));
-        onImagesChange(speciesId, [...selectedImages, ...newImages]);
+        await uploadToPool(
+          result.assets.map((asset) => ({ uri: asset.uri, name: asset.fileName ?? undefined })),
+        );
       }
     }
   };
@@ -254,13 +328,19 @@ export default function SpeciesImagePicker({
                 UPLOAD NEW
               </Text>
               <TouchableOpacity
-                style={[styles.uploadRow, { borderColor: c.border }, isAtMax && styles.uploadRowDisabled]}
+                style={[styles.uploadRow, { borderColor: c.border }, (isAtMax || uploading) && styles.uploadRowDisabled]}
                 onPress={handleUpload}
-                disabled={isAtMax}
+                disabled={isAtMax || uploading}
               >
-                <Ionicons name="cloud-upload-outline" size={20} color={isAtMax ? '#94a3b8' : '#10B981'} />
+                {uploading ? (
+                  <ActivityIndicator size="small" color="#10B981" />
+                ) : (
+                  <Ionicons name="cloud-upload-outline" size={20} color={isAtMax ? '#94a3b8' : '#10B981'} />
+                )}
                 <Text style={[styles.uploadText, { color: isAtMax ? '#94a3b8' : c.text }]}>
-                  {isAtMax
+                  {uploading
+                    ? 'Uploading…'
+                    : isAtMax
                     ? `Limit reached (${MAX_IMAGES} max)`
                     : `Choose image${MAX_IMAGES - selectedImages.length > 1 ? 's' : ''} from device`}
                 </Text>

--- a/frontend/app/screens/researcher/EditTaskScreen.tsx
+++ b/frontend/app/screens/researcher/EditTaskScreen.tsx
@@ -1,6 +1,7 @@
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import React, { useEffect, useState } from "react";
 import {
+  ActivityIndicator,
   Alert,
   ScrollView,
   StyleSheet,
@@ -16,6 +17,9 @@ import { apiFetch } from "../../api/apiFetch";
 import ScreenHeaderLayout from "../../components/layout/ScreenHeaderLayout";
 import { useQueryClient } from "@tanstack/react-query";
 import MultiSelect from "../../components/ui/MultiSelect";
+import SpeciesImagePicker from "../../components/researcher/addTask/SpeciesImagePicker";
+import { SpeciesRefImage } from "../../components/researcher/addTask/addTaskTypes";
+import { useSpeciesPoolImages, QUERY_KEYS } from "../../api/queries";
 import { researcherStackParamList } from "../../navigation/researcherStack.types";
 import { useThemeStore } from '../../stores/themeStore';
 
@@ -32,6 +36,8 @@ export default function EditTaskScreen({ route, navigation }: Props) {
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [targetSpecies, setTargetSpecies] = useState<string[]>([]);
+  // Maps species name → its selected/uploaded reference images.
+  const [speciesReferenceImages, setSpeciesReferenceImages] = useState<Record<string, SpeciesRefImage[]>>({});
   const [selectedRecipients, setSelectedRecipients] = useState<string[]>([]);
   const [sharedWithResearchers, setSharedWithResearchers] = useState<string[]>([]);
   const [selectedExperiments, setSelectedExperiments] = useState<string[]>([]);
@@ -44,6 +50,14 @@ export default function EditTaskScreen({ route, navigation }: Props) {
   const [isPublic, setIsPublic] = useState(false);
   const { theme } = useThemeStore();
   const themeColors = Colors[theme as keyof typeof Colors];
+
+  // Fetch the reference-image pool for the currently-selected species (by name).
+  const { data: poolImagesRaw, isLoading: poolImagesLoading } = useSpeciesPoolImages(targetSpecies);
+  const poolImages = poolImagesRaw ?? {};
+
+  const handleImagesChange = (speciesName: string, images: SpeciesRefImage[]) => {
+    setSpeciesReferenceImages((prev) => ({ ...prev, [speciesName]: images }));
+  };
 
   useEffect(() => {
     const fetchOptions = async () => {
@@ -102,6 +116,30 @@ export default function EditTaskScreen({ route, navigation }: Props) {
             ?.map((s: any) => String(s.name)) || []
         );
 
+        // Seed the per-species reference images from the task's existing pool selections.
+        // The backend returns imageUrl as "/api/v1/species/reference-images/{id}/image";
+        // parse the pool id from it so the images show as pre-selected and round-trip on save.
+        const seeded: Record<string, SpeciesRefImage[]> = {};
+        (data.targetSpecies || []).forEach((s: any) => {
+          const imgs = (s.referenceImages || [])
+            .map((img: any): SpeciesRefImage | null => {
+              const match = typeof img.imageUrl === "string"
+                ? img.imageUrl.match(/reference-images\/(\d+)\//)
+                : null;
+              if (!match) return null;
+              const poolId = Number(match[1]);
+              return {
+                poolId,
+                uri: API_ENDPOINTS.SPECIES.REF_THUMB_URL(poolId),
+                fromPool: true,
+                caption: img.caption,
+              };
+            })
+            .filter(Boolean) as SpeciesRefImage[];
+          if (imgs.length > 0) seeded[String(s.name)] = imgs;
+        });
+        setSpeciesReferenceImages(seeded);
+
         setSelectedExperiments(data.experiments?.map((id: number) => String(id)) || []);
 
         setIsPublic(data.isPublic || false);
@@ -122,23 +160,55 @@ export default function EditTaskScreen({ route, navigation }: Props) {
       return;
     }
 
-    const payload = {
-      status: "ACTIVE",
-      name,
-      description,
-      experiments: selectedExperiments.map(Number),
-      targetSpecies: targetSpecies.map((s) => ({
-        name: s,
-        referenceImages: [],
-      })),
-      isPublic,
-      recipientGroups: selectedRecipients.filter(id => id.startsWith("G-")).map(id => Number(id.replace("G-", ""))),
-      assignedUsernames: selectedRecipients.filter(id => id.startsWith("U-")).map(id => id.replace("U-", "")),
-      sharedWithResearchers,
-    };
-
     try {
       setLoading(true);
+
+      // Resolve each species' reference images to pool image IDs. Uploads now happen
+      // immediately in SpeciesImagePicker, so entries are normally fromPool already;
+      // any local straggler is uploaded here (mirrors the create-task flow).
+      const speciesReferenceImageIds: Record<string, number[]> = {};
+      await Promise.all(
+        targetSpecies.map(async (speciesName) => {
+          const imgs = speciesReferenceImages[speciesName] ?? [];
+          const poolIds: number[] = [];
+          for (const img of imgs) {
+            if (img.fromPool && img.poolId != null) {
+              poolIds.push(img.poolId);
+            } else {
+              const fd = new FormData();
+              const file = (img as any)._file as File | undefined;
+              if (file) {
+                fd.append("files", file);
+              } else {
+                fd.append("files", { uri: img.uri, name: "ref.jpg", type: "image/jpeg" } as any);
+              }
+              if (img.caption) fd.append("caption", img.caption);
+              const res = await apiFetch(API_ENDPOINTS.SPECIES.REF_IMAGES(speciesName), {
+                method: "POST",
+                body: fd,
+              });
+              if (res.ok) {
+                const saved: { id: number }[] = await res.json();
+                saved.forEach((s) => poolIds.push(s.id));
+              }
+            }
+          }
+          speciesReferenceImageIds[speciesName] = poolIds;
+        })
+      );
+
+      const payload = {
+        status: "ACTIVE",
+        name,
+        description,
+        experiments: selectedExperiments.map(Number),
+        targetSpecies: targetSpecies.map((s) => ({ name: s })),
+        speciesReferenceImageIds,
+        isPublic,
+        recipientGroups: selectedRecipients.filter(id => id.startsWith("G-")).map(id => Number(id.replace("G-", ""))),
+        assignedUsernames: selectedRecipients.filter(id => id.startsWith("U-")).map(id => id.replace("U-", "")),
+        sharedWithResearchers,
+      };
 
       const res = await apiFetch(
         API_ENDPOINTS.TASKS.UPDATE_TASK(taskId),
@@ -157,8 +227,13 @@ export default function EditTaskScreen({ route, navigation }: Props) {
 
       await res.json();
 
-      queryClient.invalidateQueries({ queryKey: ["tasks"] });
-      queryClient.invalidateQueries({ queryKey: ["taskDetails", taskId] });
+      // Force immediate refetches (not lazy invalidation) so the task details
+      // page reflects the new reference images right away instead of waiting out
+      // the query's staleTime. The details/list queries all live under ['tasks'].
+      // Await the details refetch so the data is fresh before we navigate back.
+      await queryClient.refetchQueries({ queryKey: QUERY_KEYS.taskDetails(taskId) });
+      queryClient.refetchQueries({ queryKey: ["tasks"] });
+      queryClient.refetchQueries({ queryKey: ["species", "pool"] });
 
       Alert.alert("Success", "Task updated successfully");
       navigation.navigate("TasksManagement");
@@ -201,13 +276,50 @@ export default function EditTaskScreen({ route, navigation }: Props) {
           options={availableSpecies}
           selectedIds={targetSpecies}
           onToggle={(id) => {
+            const sid = id as string;
             setTargetSpecies((prev) =>
-              prev.includes(id as string) ? prev.filter((sid) => sid !== id) : [...prev, id as string]
+              prev.includes(sid) ? prev.filter((s) => s !== sid) : [...prev, sid]
             );
+            // Drop reference images for a species that was just deselected.
+            setSpeciesReferenceImages((prev) => {
+              if (!prev[sid]) return prev;
+              const { [sid]: _removed, ...rest } = prev;
+              return rest;
+            });
           }}
           placeholder="Search species..."
           loading={optionsLoading}
         />
+
+        {/* Reference image pickers — one per selected species */}
+        {targetSpecies.length > 0 && (
+          <View style={styles.pickersSection}>
+            <Text style={[styles.pickersHeading, { color: themeColors.textSecondary }]}>
+              REFERENCE IMAGES
+            </Text>
+
+            {poolImagesLoading && (
+              <View style={styles.poolLoadingRow}>
+                <ActivityIndicator size="small" color="#10B981" />
+                <Text style={[styles.poolLoadingText, { color: themeColors.textSecondary }]}>
+                  Loading pool images...
+                </Text>
+              </View>
+            )}
+
+            {targetSpecies.map((speciesName) => (
+              <SpeciesImagePicker
+                key={speciesName}
+                speciesId={speciesName}
+                speciesLabel={speciesName}
+                selectedImages={speciesReferenceImages[speciesName] ?? []}
+                poolImages={poolImages[speciesName] ?? []}
+                poolLoading={poolImagesLoading}
+                onImagesChange={handleImagesChange}
+              />
+            ))}
+          </View>
+        )}
 
         <Text style={[styles.label, { color: themeColors.text }]}>Experiments</Text>
         <MultiSelect
@@ -334,4 +446,8 @@ const styles = StyleSheet.create({
   toggleTextActive: {
     color: "#065f46",
   },
+  pickersSection: { marginTop: 8, gap: 4 },
+  pickersHeading: { fontSize: 11, fontWeight: "700", letterSpacing: 0.8, marginBottom: 8, marginTop: 12 },
+  poolLoadingRow: { flexDirection: "row", alignItems: "center", gap: 8, marginBottom: 12 },
+  poolLoadingText: { fontSize: 13 },
 });


### PR DESCRIPTION
Brings the EditTaskScreen to parity with the Create Task flow by adding the Reference Images section, reusing the existing SpeciesImagePicker component so a researcher can upload new images or select from a species' existing pool. Existing reference images are pre-selected on load and round-trip correctly on save. Fixes the bug where a newly uploaded image wasn't immediately selectable: uploads now go to the pool right away and the React Query cache is refreshed via refetchQueries (instead of lazy invalidation) so the pool grid, selected thumbnails, and the task details page all update instantly rather than waiting out the 5-minute staleTime.
